### PR TITLE
Issue #89: QA - Network selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { DevLinkProvider } from './devlink'
 
 // Toast css
 import Analytics from './containers/Analytics'
+import { ToastContainer } from "react-toastify";
 
 declare module 'styled-components' {
     export interface DefaultTheme extends Theme {}
@@ -42,6 +43,7 @@ const App = () => {
                 <DevLinkProvider>
                     <GlobalStyle bodyOverflow={bodyOverflow} />
                     <ErrorBoundary>
+                        <ToastContainer />
                         <Shared>
                             <ApolloProvider client={client}>
                                 <StatsProvider>

--- a/src/components/ToastPayload.tsx
+++ b/src/components/ToastPayload.tsx
@@ -43,6 +43,8 @@ export default ToastPayload
 const Container = styled.div`
     display: flex;
     align-items: center;
+    padding: 10px 15px;
+    background-color: ${(props) => props.theme.colors.blueish};
     svg {
         margin-right: 15px;
     }

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -38,7 +38,29 @@ export async function checkAndSwitchMetamaskNetwork() {
         // @ts-ignore
         const chainId = await window.ethereum.request({ method: 'net_version' })
         // Check if chain ID is same as REACT_APP_NETWORK_ID and prompt user to switch networks if not
-        if (chainId !== process.env.REACT_APP_NETWORK_ID) {
+        if (chainId !== process.env.REACT_APP_NETWORK_ID && process.env.REACT_APP_NETWORK_ID === '42161') {
+            try {
+                // @ts-ignore
+                await window.ethereum.request({
+                    method: 'wallet_addEthereumChain',
+                    params: [
+                        {
+                            chainId: `0xA4B1`,
+                            chainName: 'Arbitrum One',
+                            nativeCurrency: {
+                                name: 'ETH',
+                                symbol: 'ETH',
+                                decimals: 18,
+                            },
+                            rpcUrls: ['https://arbitrum-one.publicnode.com'],
+                            blockExplorerUrls: ['https://arbiscan.io/'],
+                        },
+                    ],
+                })
+            } catch (error) {
+                console.error('Failed to switch network', error)
+            }
+        } else {
             try {
                 // @ts-ignore
                 await window.ethereum.request({

--- a/src/components/connectorCards/CoinbaseWalletCard.tsx
+++ b/src/components/connectorCards/CoinbaseWalletCard.tsx
@@ -19,7 +19,7 @@ import { useEffect, useState } from 'react'
 import { coinbaseWallet, hooks } from '../../connectors/coinbaseWallet'
 import { Card } from './Card'
 
-const { useChainId, useAccounts, useIsActivating, useIsActive, useProvider, useENSNames } = hooks
+const { useChainId, useAccounts, useIsActivating, useIsActive, useProvider } = hooks
 
 export default function CoinbaseWalletCard() {
     const chainId = useChainId()
@@ -29,16 +29,9 @@ export default function CoinbaseWalletCard() {
     const isActive = useIsActive()
 
     const provider = useProvider()
-    const ENSNames = useENSNames(provider)
 
     const [error, setError] = useState(undefined)
 
-    // attempt to connect eagerly on mount
-    useEffect(() => {
-        void coinbaseWallet.connectEagerly().catch(() => {
-            console.debug('Failed to connect eagerly to coinbase wallet')
-        })
-    }, [])
 
     return (
         <Card
@@ -51,7 +44,6 @@ export default function CoinbaseWalletCard() {
             setError={setError}
             accounts={accounts}
             provider={provider}
-            ENSNames={ENSNames}
         />
     )
 }

--- a/src/components/connectorCards/CoinbaseWalletCard.tsx
+++ b/src/components/connectorCards/CoinbaseWalletCard.tsx
@@ -32,6 +32,11 @@ export default function CoinbaseWalletCard() {
 
     const [error, setError] = useState(undefined)
 
+    // attempt to connect eagerly on mount
+    useEffect(() => {
+        void coinbaseWallet.connectEagerly().catch(() => {
+        })
+    }, [])
 
     return (
         <Card

--- a/src/components/connectorCards/MetaMaskCard.tsx
+++ b/src/components/connectorCards/MetaMaskCard.tsx
@@ -19,7 +19,7 @@ import { useEffect, useState } from 'react'
 import { hooks, metaMask } from '../../connectors/metaMask'
 import { Card } from '~/components/connectorCards/Card'
 
-const { useChainId, useAccounts, useIsActivating, useIsActive, useProvider, useENSNames } = hooks
+const { useChainId, useAccounts, useIsActivating, useIsActive, useProvider } = hooks
 
 export default function MetaMaskCard() {
     const chainId = useChainId()
@@ -31,13 +31,6 @@ export default function MetaMaskCard() {
     const provider = useProvider()
 
     const [error, setError] = useState(undefined)
-
-    // attempt to connect eagerly on mount
-    useEffect(() => {
-        void metaMask.connectEagerly().catch(() => {
-            console.debug('Failed to connect eagerly to metamask')
-        })
-    }, [])
 
     return (
         <Card

--- a/src/components/connectorCards/MetaMaskCard.tsx
+++ b/src/components/connectorCards/MetaMaskCard.tsx
@@ -32,6 +32,11 @@ export default function MetaMaskCard() {
 
     const [error, setError] = useState(undefined)
 
+    useEffect(() => {
+        void metaMask.connectEagerly().catch(() => {
+        })
+    }, [])
+
     return (
         <Card
             activate={false}

--- a/src/components/connectorCards/WalletConnectCard.tsx
+++ b/src/components/connectorCards/WalletConnectCard.tsx
@@ -20,7 +20,7 @@ import { useEffect, useState } from 'react'
 import { hooks, walletConnect } from '../../connectors/walletConnect'
 import { Card } from './Card'
 
-const { useChainId, useAccounts, useIsActivating, useIsActive, useProvider, useENSNames } = hooks
+const { useChainId, useAccounts, useIsActivating, useIsActive, useProvider } = hooks
 
 export default function WalletConnectCard() {
     const chainId = useChainId()
@@ -30,7 +30,6 @@ export default function WalletConnectCard() {
     const isActive = useIsActive()
 
     const provider = useProvider()
-    const ENSNames = useENSNames(provider)
 
     const [error, setError] = useState(undefined)
 
@@ -41,12 +40,6 @@ export default function WalletConnectCard() {
         })
     }, [])
 
-    // attempt to connect eagerly on mount
-    useEffect(() => {
-        walletConnect.connectEagerly().catch(() => {
-            console.debug('Failed to connect eagerly to walletconnect')
-        })
-    }, [])
 
     return (
         <Card
@@ -59,7 +52,6 @@ export default function WalletConnectCard() {
             setError={setError}
             accounts={accounts}
             provider={provider}
-            ENSNames={ENSNames}
         />
     )
 }

--- a/src/components/connectorCards/WalletConnectV2Card.tsx
+++ b/src/components/connectorCards/WalletConnectV2Card.tsx
@@ -43,6 +43,11 @@ export default function WalletConnectV2Card() {
         })
     }, [])
 
+    // attempt to connect eagerly on mount
+    useEffect(() => {
+        walletConnectV2.connectEagerly().catch(() => {
+        })
+    }, [])
 
     return (
         <Card

--- a/src/components/connectorCards/WalletConnectV2Card.tsx
+++ b/src/components/connectorCards/WalletConnectV2Card.tsx
@@ -23,7 +23,7 @@ import { Card } from './Card'
 
 const CHAIN_IDS = Object.keys(MAINNET_CHAINS).map(Number)
 
-const { useChainId, useAccounts, useIsActivating, useIsActive, useProvider, useENSNames } = hooks
+const { useChainId, useAccounts, useIsActivating, useIsActive, useProvider } = hooks
 
 export default function WalletConnectV2Card() {
     const chainId = useChainId()
@@ -43,12 +43,6 @@ export default function WalletConnectV2Card() {
         })
     }, [])
 
-    // attempt to connect eagerly on mount
-    useEffect(() => {
-        walletConnectV2.connectEagerly().catch((error) => {
-            console.debug('Failed to connect eagerly to walletconnect', error)
-        })
-    }, [])
 
     return (
         <Card

--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -76,7 +76,7 @@ const Shared = ({ children, ...rest }: Props) => {
         safeModel: safeActions,
         auctionModel: { setCoinBalances, setProtInternalBalance, setInternalBalance },
     } = useStoreActions((state) => state)
-    const toastId = 'networdToastHash'
+    const toastId = 'networkToastHash'
     const successAccountConnection = 'successAccountConnection'
 
     const resetModals = () => {
@@ -215,21 +215,19 @@ const Shared = ({ children, ...rest }: Props) => {
                     icon={'AlertTriangle'}
                     iconSize={40}
                     iconColor={'orange'}
-                    textColor={'#272727'}
+                    textColor={'#ffffff'}
                     text={`${t('wrong_network')} ${capitalizeName(chainName === '' ? 'Arbitrum' : chainName)}`}
                 />,
                 { autoClose: false, type: 'warning', toastId }
             )
             await checkAndSwitchMetamaskNetwork()
         } else {
-            toast.update(toastId, { autoClose: 1 })
+            if (document.querySelector("#networkToastHash") !== null) {
+                document.querySelector("#networkToastHash")?.remove();
+            }
             settingsActions.setBlockBody(false)
             connectWalletActions.setIsWrongNetwork(false)
             if (account) {
-                toast(<ToastPayload icon={'Check'} iconColor={'green'} text={t('wallet_connected')} />, {
-                    type: 'success',
-                    toastId: successAccountConnection,
-                })
                 connectWalletActions.setStep(1)
                 accountChecker()
             }

--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -26,7 +26,7 @@ import BalanceUpdater from '~/services/BalanceUpdater'
 import WethModal from '~/components/Modals/WETHModal'
 import ToastPayload from '~/components/ToastPayload'
 import CookieBanner from '~/components/CookieBanner'
-import WalletModal from '~/components/WalletModal'
+import WalletModal, { checkAndSwitchMetamaskNetwork } from '~/components/WalletModal'
 import AlertLabel from '~/components/AlertLabel'
 import usePrevious from '~/hooks/usePrevious'
 import SideMenu from '~/components/SideMenu'
@@ -203,14 +203,13 @@ const Shared = ({ children, ...rest }: Props) => {
         }
     }
 
-    function networkChecker() {
+    async function networkChecker() {
         accountChange()
         const id: ChainId = NETWORK_ID
         popupsActions.setIsSafeManagerOpen(false)
         if (chainId && chainId !== id) {
             const chainName = ETHERSCAN_PREFIXES[id]
             connectWalletActions.setIsWrongNetwork(true)
-            settingsActions.setBlockBody(true)
             toast(
                 <ToastPayload
                     icon={'AlertTriangle'}
@@ -221,6 +220,7 @@ const Shared = ({ children, ...rest }: Props) => {
                 />,
                 { autoClose: false, type: 'warning', toastId }
             )
+            await checkAndSwitchMetamaskNetwork()
         } else {
             toast.update(toastId, { autoClose: 1 })
             settingsActions.setBlockBody(false)

--- a/src/model/connectWalletModel.ts
+++ b/src/model/connectWalletModel.ts
@@ -81,7 +81,12 @@ const connectWalletModel: ConnectWalletModel = {
     }),
     fetchTokenData: thunk(async (actions, payload) => {
         const tokenList = payload.geb.tokenList
-        const fetched = await fetchTokenData(payload.geb, payload.user, tokenList)
+        let fetched;
+        try {
+            fetched = await fetchTokenData(payload.geb, payload.user, tokenList)
+        } catch (e) {
+            console.debug('Error fetching token data', e)
+        }
         if (fetched) {
             actions.setTokensFetchedData(fetched)
             actions.setForceUpdateTokens(false)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -92,8 +92,8 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
 }
 
 export const ETHERSCAN_PREFIXES: { [chainId in ChainId]: string } = {
-    42161: '',
-    421613: 'goerli.',
+    42161: 'Arbitrum One',
+    421613: 'Arbitrum Goerli.',
 }
 
 const MEDIA_WIDTHS = {

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -30,7 +30,14 @@ export const getEtherscanLink = (
     data: string,
     type: 'transaction' | 'token' | 'address' | 'block'
 ): string => {
-    const prefix = `https://${ETHERSCAN_PREFIXES[chainId] || ETHERSCAN_PREFIXES[42161]}arbiscan.io`
+    let blockExplorerPrefix;
+    // No special prefix for Arbitrum One's block explorer. Otherwise, use Arbitrum Goerli's block explorer
+    if (chainId.toString() === '42161') {
+        blockExplorerPrefix = ''
+    } else {
+        blockExplorerPrefix = 'goerli'
+    }
+    const prefix = `https://${blockExplorerPrefix}arbiscan.io`
 
     switch (type) {
         case 'transaction': {


### PR DESCRIPTION
Closes #89

## Description
- Added logic to check if user is on right network when *already* connected to the app and if not, prompt them to switch networks--i'm specifying arbitrum goerli here but do we want to add support for arbitrum yet?
- Removed the overlay over the body when on the wrong network (setBlockBody(true))
- Removed connectEagerly logic from wallet components (the wallet persists anyway thanks to our context provider so it's unnecessary) 
- Added error handling to a token fetching call that was throwing errors that weren't caught
- Removed unused ENS logic from wallet components

## Screenshots

Switch networks 

https://github.com/UseKeyp/od-app/assets/47253537/0702255d-93b6-4e39-b8a3-9aa9bfa0a37c

Connect eagerly not needed--wallet connection persists anyway

https://github.com/UseKeyp/od-app/assets/47253537/5c8cae55-9be8-426c-9e32-6a4d579cdf2c


