### PR TITLE
Issue #81: QA - Wallet connect modal styling 

### DIFF
--- a/src/components/connectorCards/Card.tsx
+++ b/src/components/connectorCards/Card.tsx
@@ -129,7 +129,7 @@ export function Card({ connector, activeChainId, isActivating, isActive, error, 
                     textAlign: 'left',
                 }}
             >
-                <span>{getName(connector)}</span>
+                <span style={{ fontSize: '20px' }}>{getName(connector)}</span>
                 <div>
                     <Status isActivating={isActivating} isActive={isActive} error={error} />
                 </div>

--- a/src/components/connectorCards/Status.tsx
+++ b/src/components/connectorCards/Status.tsx
@@ -26,7 +26,7 @@ export function Status({
     error?: Error
 }) {
     return (
-        <div>
+        <div style={{fontWeight: 'normal'}}>
             {error ? (
                 <>
                     🔴 {error.name ?? 'Error'}


### PR DESCRIPTION
Closes #81 

## Description
- change wallet name to 20px
- status / description text is now normal size not bold

## Screenshots

Before

<img width="567" alt="Screenshot 2023-08-25 at 5 05 32 PM" src="https://github.com/UseKeyp/od-app/assets/47253537/f42d3ad2-d37e-45fb-b1c0-419d891bbd9e">

After 

<img width="1010" alt="Screenshot 2023-08-25 at 4 49 23 PM" src="https://github.com/UseKeyp/od-app/assets/47253537/6de7aab0-11ed-431d-8d82-84464ebca861">

<img width="483" alt="Screenshot 2023-08-25 at 4 49 43 PM" src="https://github.com/UseKeyp/od-app/assets/47253537/c8ec56a9-8cf5-45c5-8b7d-f1c98a39d3c9">

