### PR TITLE
Issue #99: Validate OD Borrowed > 0 During Deposit & Borrow

### DIFF
--- a/src/hooks/useSafe.ts
+++ b/src/hooks/useSafe.ts
@@ -245,6 +245,9 @@ export function useSafeInfo(type: SafeTypes = 'create') {
             error =
                 error ?? `Please enter the amount of ${collateralName} to be deposited or amount of OD to be borrowed`
         }
+        if (rightInputBN.isZero()) {
+            error = error ?? 'OD borrowed cannot be zero'
+        }
     }
 
     if (type === 'repay_withdraw') {


### PR DESCRIPTION
Closes #99 

## Description

- Added validation to ensure user does not try to deposit & borrow when OD === 0

## Screenshots

https://github.com/open-dollar/od-app/assets/47253537/e32e8581-fd74-437f-8798-66b9888370a2

