### PR TITLE
Issue #113: QA vaults hidden

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import Logo from '../assets/od-full-logo-grey.svg'
 import { useStoreActions } from '~/store'
 import { Link as RouterLink } from 'react-router-dom'
-import { useHistory } from 'react-router-dom'
+import FooterBackgroundImage from '~/assets/footer-bg-art.svg'
 
 const Footer: React.FC = () => {
     const { popupsModel: popupsActions } = useStoreActions((state) => state)
@@ -19,86 +19,116 @@ const Footer: React.FC = () => {
         }
     }
     return (
-        <FooterContainer>
-            <Row className="logoRow">
-                <Column>
-                    <LogoContainer>
-                        <a href={'/'}>
-                            <img src={Logo} height={'13px'} width={'89px'} alt="OD" />
-                        </a>
-                    </LogoContainer>
-                </Column>
-            </Row>
-            <Row className="linksRow">
-                <Column>
-                    <Link target="_blank" href="https://opendollar.com/blog">
-                        Blog
-                    </Link>
-                    <Link target="_blank" href="https://opendollar.com/lite-paper">
-                        Lite Paper
-                    </Link>
-                </Column>
-                <Column>
-                    <InnerLink
-                        to="/vaults"
-                        onClick={(e) => handleLinkClick(e, false)}
-                        className={location.pathname.startsWith('/vaults') ? 'activeLink' : ''}
-                    >
-                        App
-                    </InnerLink>
-                    <InnerLink
-                        to="/auctions"
-                        onClick={(e) => handleLinkClick(e, false)}
-                        className={location.pathname.startsWith('/auctions') ? 'activeLink' : ''}
-                    >
-                        Auctions
-                    </InnerLink>
-                    <InnerLink
-                        to="/stats"
-                        onClick={(e) => handleLinkClick(e, false)}
-                        className={location.pathname.startsWith('/stats') ? 'activeLink' : ''}
-                    >
-                        Stats
-                    </InnerLink>
-                </Column>
-                <Column>
-                    <Link target="_blank" href="https://discord.opendollar.com">
-                        Discord
-                    </Link>
-                    <Link target="_blank" href="https://twitter.com/open_dollar">
-                        Twitter
-                    </Link>
-                </Column>
-            </Row>
-            <Row className="privacyRow">
-                <Column>
-                    <SmallerLink
-                        target="_blank"
-                        href="https://www.usekeyp.com/terms-of-use-privacy-policy#Privacy-Policy"
-                    >
-                        Privacy Policy
-                    </SmallerLink>
-                    <SmallerLink
-                        target="_blank"
-                        href="https://www.usekeyp.com/terms-of-use-privacy-policy#Terms-of-Use"
-                    >
-                        Terms of Service
-                    </SmallerLink>
-                </Column>
-            </Row>
-        </FooterContainer>
+        <FooterAndImageContainer>
+            <FooterContainer>
+                <Row className="logoRow">
+                    <Column>
+                        <LogoContainer>
+                            <a href={'/'}>
+                                <img src={Logo} height={'13px'} width={'89px'} alt="OD" />
+                            </a>
+                        </LogoContainer>
+                    </Column>
+                </Row>
+                <Row className="linksRow">
+                    <Column>
+                        <Link target="_blank" href="https://opendollar.com/blog">
+                            Blog
+                        </Link>
+                        <Link target="_blank" href="https://opendollar.com/lite-paper">
+                            Lite Paper
+                        </Link>
+                    </Column>
+                    <Column>
+                        <InnerLink
+                            to="/vaults"
+                            onClick={(e) => handleLinkClick(e, false)}
+                            className={location.pathname.startsWith('/vaults') ? 'activeLink' : ''}
+                        >
+                            App
+                        </InnerLink>
+                        <InnerLink
+                            to="/auctions"
+                            onClick={(e) => handleLinkClick(e, false)}
+                            className={location.pathname.startsWith('/auctions') ? 'activeLink' : ''}
+                        >
+                            Auctions
+                        </InnerLink>
+                        <InnerLink
+                            to="/stats"
+                            onClick={(e) => handleLinkClick(e, false)}
+                            className={location.pathname.startsWith('/stats') ? 'activeLink' : ''}
+                        >
+                            Stats
+                        </InnerLink>
+                    </Column>
+                    <Column>
+                        <Link target="_blank" href="https://discord.opendollar.com">
+                            Discord
+                        </Link>
+                        <Link target="_blank" href="https://twitter.com/open_dollar">
+                            Twitter
+                        </Link>
+                    </Column>
+                </Row>
+                <Row className="privacyRow">
+                    <Column>
+                        <SmallerLink
+                            target="_blank"
+                            href="https://www.usekeyp.com/terms-of-use-privacy-policy#Privacy-Policy"
+                        >
+                            Privacy Policy
+                        </SmallerLink>
+                        <SmallerLink
+                            target="_blank"
+                            href="https://www.usekeyp.com/terms-of-use-privacy-policy#Terms-of-Use"
+                        >
+                            Terms of Service
+                        </SmallerLink>
+                    </Column>
+                </Row>
+            </FooterContainer>
+            <FooterImage>
+                <img src={FooterBackgroundImage} alt="" />
+            </FooterImage>
+        </FooterAndImageContainer>
     )
 }
 
 export default Footer
 
+const FooterAndImageContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+`
+
+const FooterImage = styled.div`
+    //position: fixed;
+    //bottom: 0;
+    //left: 0;
+    display: flex;
+    width: 100%;
+    z-index: -1;
+    img {
+        width: 100%;
+    }
+`
+
 const FooterContainer = styled.div`
     display: flex;
+    padding-top: 80px;
+    //position: fixed;
+    bottom: 170px;
+    width: 100%;
     flex-direction: row;
     justify-content: space-around;
     color: ${(props) => props.theme.colors.blueish};
 
     @media (max-width: 767px) {
+        bottom: 117px;
         flex-direction: column;
         justify-content: center;
     }
@@ -132,7 +162,13 @@ const Column = styled.div`
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
-    margin: 0 20px;
+    padding-left: 10px;
+    padding-right: 10px;
+
+    @media (max-width: 767px) {
+        padding-left: 20px;
+        padding-right: 20px;
+    }
 `
 
 const LogoContainer = styled.div`

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -106,9 +106,6 @@ const FooterAndImageContainer = styled.div`
 `
 
 const FooterImage = styled.div`
-    //position: fixed;
-    //bottom: 0;
-    //left: 0;
     display: flex;
     width: 100%;
     z-index: -1;
@@ -120,7 +117,6 @@ const FooterImage = styled.div`
 const FooterContainer = styled.div`
     display: flex;
     padding-top: 80px;
-    //position: fixed;
     bottom: 170px;
     width: 100%;
     flex-direction: row;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -483,6 +483,9 @@ const ArrowWrapper = styled.div`
 const ClaimButton = styled(OdButton)``
 
 const DollarValue = styled(OdButton)`
-    width: 133px;
+    display: flex;
+    align-items: center;
     justify-content: space-between;
+    width: auto;
+    white-space: nowrap;
 `

--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -278,8 +278,9 @@ const Shared = ({ children, ...rest }: Props) => {
                 <CookieBanner />
             </EmptyDiv>
             <ImagePreloader />
-            <Footer />
-            <img src={FooterBackgroundImage} alt="" />
+            <EmptyDiv>
+                <Footer />
+            </EmptyDiv>
         </Container>
     )
 }


### PR DESCRIPTION
Closes #113 

## Description
- [X] OD amount is wrapping 
Fixed by setting no-wrap and having width expand dynamically

- [X] Footer image is not placed correctly. There should not be padding below the image (page height issue), and there should be more padding above the footer to keep it away from content 

Fixed footer issues by removing fixed positioning, moving image to footer, modifying padding

- [ ] Vaults you do not own should still be visible

I determined this needs to be added at the smart contract level--in the SDK the only function available to fetch safes is via fetchUserSafes in the SDK and this is passing in an address. I looked in the ABI for functions we could use to fetch safes in other ways and in HaiSafeManager.json we have the following functions available:

```
 "getSafes(address)": "61120929",
    "getSafes(address,bytes32)": "7896835e",
    "getSafesData(address)": "4e1db2bb",
```

We need a read method in the ABI to fetch safes by ID. In the SDK the ReadMe shows this:
```
let safe = await geb.getSafe(4)
```
However, this was never implemented anywhere

## Screenshots

OD amount with three digits

<img width="259" alt="afterNav" src="https://github.com/open-dollar/od-app/assets/47253537/677b2320-e2e5-4d36-a614-0e2d5e96f516">

OD amount responsive

https://github.com/open-dollar/od-app/assets/47253537/65871a8b-2e57-498f-9b8a-d7d1d9d1b02a

Demo of footer changes w/vaults

https://github.com/open-dollar/od-app/assets/47253537/bf3e7dc0-38e0-4459-955e-b3bcd7fbc315

Demo of footer changes without vaults

https://github.com/open-dollar/od-app/assets/47253537/829bb120-f3dc-4bb6-ba98-a184dcadf6ce












