### PR TITLE
Issue #120: QA 9-18

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,9 +2,8 @@ import React, { useMemo, useState, useRef, useEffect } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-import { utils } from 'ethers'
 
-import { formatNumber, getTokenLogo, newTransactionsFirst, returnWalletAddress } from '~/utils'
+import { formatDataNumber, getTokenLogo, newTransactionsFirst, returnWalletAddress } from '~/utils'
 import { useStoreActions, useStoreState } from '~/store'
 import { handleTransactionError, isTransactionRecent } from '~/hooks'
 import Identicon from './Icons/Identicon'
@@ -36,7 +35,9 @@ const Navbar = () => {
     const { isActive, account, provider } = useWeb3React()
     const odRef = useRef<HTMLButtonElement | null>(null)
     const tokenPopupRef = useRef<HTMLDivElement | null>(null)
+    const testTokenPopupRef = useRef<HTMLDivElement | null>(null)
     const [isTokenPopupVisible, setTokenPopupVisibility] = useState(false)
+    const [isTestTokenPopupVisible, setTestTokenPopupVisibility] = useState(false)
     const signer = provider ? provider.getSigner(account) : undefined
 
     const handleTokenClick = () => {
@@ -118,7 +119,7 @@ const Navbar = () => {
 
     const odBalance = useMemo(() => {
         const balances = connectWalletModel.tokensFetchedData
-        return formatNumber(balances.OD ? utils.formatEther(balances.OD.balanceE18) : '0', 2)
+        return formatDataNumber(balances.OD ? balances.OD.balanceE18.toString() : '0', 2, 2, false)
     }, [connectWalletModel.tokensFetchedData])
 
     const claimAirdropButton = async (signer: any) => {
@@ -191,19 +192,33 @@ const Navbar = () => {
                     )}
                 </Price>
             </Left>
-
             <HideMobile>
                 <NavLinks />
             </HideMobile>
             <RightSide>
                 <BtnContainer>
                     {signer && (
-                        <ClaimButton onClick={() => signer && claimAirdropButton(signer)}>
-                            Claim test tokens 🪂
-                        </ClaimButton>
+                        <>
+                            <ClaimButton onClick={() => setTestTokenPopupVisibility(!isTestTokenPopupVisible)}>
+                                Test tokens 🪂
+                                <ArrowWrapper>
+                                    <ArrowDown fill={isTestTokenPopupVisible ? '#1499DA' : '#00587E'} />
+                                </ArrowWrapper>
+                            </ClaimButton>
+                            {isTestTokenPopupVisible && (
+                                <TestTokenPopup ref={testTokenPopupRef} className="group">
+                                    <TestTokenTextWrapper>
+                                        USE THE /CLAIM COMMAND IN OUR{' '}
+                                        <a target="blank" href="https://discord.opendollar.com/">
+                                            DISCORD
+                                        </a>
+                                    </TestTokenTextWrapper>
+                                </TestTokenPopup>
+                            )}
+                        </>
                     )}
                     {/* Button to add OD and ODG to the wallet */}
-                    <Price>
+                    <RightPriceWrapper>
                         <DollarValue ref={odRef} onClick={handleTokenClick}>
                             <Icon
                                 src={require('../assets/od-wallet-icon.svg').default}
@@ -248,7 +263,7 @@ const Navbar = () => {
                                 </PopupColumnWrapper>
                             </PriceInfoPopup>
                         )}
-                    </Price>
+                    </RightPriceWrapper>
 
                     {/* Button to connect wallet */}
                     <Button
@@ -361,7 +376,7 @@ const BtnContainer = styled.div`
 
     svg {
         position: relative;
-        margin-right: 5px;
+        margin-right: 0px;
     }
 `
 
@@ -440,6 +455,15 @@ const OdButton = styled.button`
     }
 `
 
+const RightPriceWrapper = styled.div`
+    position: relative;
+    margin-right: auto;
+
+    @media (max-width: ${screenWidth}) {
+        display: none;
+    }
+`
+
 const Price = styled.div`
     position: relative;
     margin-right: auto;
@@ -450,13 +474,31 @@ const Price = styled.div`
     }
 `
 
-const PriceInfoPopup = styled.div`
+const TestTokenTextWrapper = styled.div`
+    font-size: ${(props) => props.theme.font.extraSmall};
+    text-align: left;
+    font-weight: 600;
+    color: #0079ad;
+    word-wrap: break-word;
+    max-width: 100%;
+`
+
+const TestTokenPopup = styled.div`
     position: absolute;
-    min-width: 180px;
+    max-width: 150px;
     padding: 8px;
     background: ${(props) => props.theme.colors.colorPrimary};
     border-radius: 8px;
-    top: 56px;
+    top: 80px;
+`
+
+const PriceInfoPopup = styled.div`
+    position: absolute;
+    min-width: 160px;
+    padding: 8px;
+    background: ${(props) => props.theme.colors.colorPrimary};
+    border-radius: 8px;
+    top: 45px;
 `
 
 const PopupWrapperLink = styled.a`

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -178,7 +178,7 @@ const Navbar = () => {
                         </ArrowWrapper>
                     </DollarValue>
                     {isPopupVisible && (
-                        <PriceInfoPopup ref={popupRef} className="group">
+                        <LiquidityInfoPopup ref={popupRef} className="group">
                             <PopupWrapperLink className="group">
                                 <IconWrapper>
                                     <Uniswap />
@@ -188,7 +188,7 @@ const Navbar = () => {
                                     <div>Delta B: +735.14</div>
                                 </PoupColumn>
                             </PopupWrapperLink>
-                        </PriceInfoPopup>
+                        </LiquidityInfoPopup>
                     )}
                 </Price>
             </Left>
@@ -490,6 +490,15 @@ const TestTokenPopup = styled.div`
     background: ${(props) => props.theme.colors.colorPrimary};
     border-radius: 8px;
     top: 80px;
+`
+
+const LiquidityInfoPopup = styled.div`
+    position: absolute;
+    min-width: 180px;
+    padding: 8px;
+    background: ${(props) => props.theme.colors.colorPrimary};
+    border-radius: 8px;
+    top: 45px;
 `
 
 const PriceInfoPopup = styled.div`

--- a/src/components/connectorCards/MetaMaskCard.tsx
+++ b/src/components/connectorCards/MetaMaskCard.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState } from 'react'
 
 import { hooks, metaMask } from '../../connectors/metaMask'
 import { Card } from '~/components/connectorCards/Card'
+import { useStoreActions } from '~/store'
 
 const { useChainId, useAccounts, useIsActivating, useIsActive, useProvider } = hooks
 
@@ -30,12 +31,16 @@ export default function MetaMaskCard() {
 
     const provider = useProvider()
 
+    const { popupsModel: popupsActions, connectWalletModel: connectWalletActions } = useStoreActions((state) => state)
+
     const [error, setError] = useState(undefined)
 
     useEffect(() => {
-        void metaMask.connectEagerly().catch(() => {
-        })
-    }, [])
+        void metaMask.connectEagerly().catch(() => {})
+        if (isActive && provider?.provider.isMetaMask) {
+            popupsActions.setIsConnectorsWalletOpen(false)
+        }
+    }, [isActive])
 
     return (
         <Card

--- a/src/components/connectorCards/MetaMaskCard.tsx
+++ b/src/components/connectorCards/MetaMaskCard.tsx
@@ -37,10 +37,10 @@ export default function MetaMaskCard() {
 
     useEffect(() => {
         void metaMask.connectEagerly().catch(() => {})
-        if (isActive && provider?.provider.isMetaMask) {
+        if (provider?.provider.isMetaMask && accounts) {
             popupsActions.setIsConnectorsWalletOpen(false)
         }
-    }, [isActive])
+    }, [accounts])
 
     return (
         <Card

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -69,13 +69,11 @@ const TESTNET_CHAINS = {
 const [testnet, ...optionalChains] = Object.keys(TESTNET_CHAINS).map(Number)
 
 export const walletconnect = initializeConnector<WalletConnectV2>(
-    // @ts-ignore
     (actions) =>
         new WalletConnectV2({
             actions,
             options: {
-                // @ts-ignore
-                projectId: process.env.WALLET_CONNECT_PROJECT_ID,
+                projectId: process.env.REACT_APP_WALLET_CONNECT_PROJECT_ID as string,
                 chains: [testnet, ...optionalChains],
                 optionalChains,
                 showQrModal: true,

--- a/src/connectors/walletConnectV2.ts
+++ b/src/connectors/walletConnectV2.ts
@@ -30,7 +30,7 @@ export const [walletConnectV2, hooks] = initializeConnector<WalletConnectV2>(
         new WalletConnectV2({
             actions,
             options: {
-                projectId: 'c8d728041790027d6469878911bff5cf',
+                projectId: process.env.REACT_APP_WALLET_CONNECT_PROJECT_ID as string,
                 chains: [supportedChainId],
                 showQrModal: true,
             },

--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -339,7 +339,7 @@ const Analytics = () => {
                     erc20Supply: formatDataNumber(result.erc20Supply, 18, 0, true),
                     globalDebt: formatDataNumber(result.globalDebt, 18, 0, true),
                     globalDebtCeiling: formatDataNumber(result.globalDebtCeiling, 18, 0, true),
-                    globalDebtUtilization: transformToWadPercentage(result.globalDebt, result.globalDebtCeiling, 3),
+                    globalDebtUtilization: transformToWadPercentage(result.globalDebt, result.globalDebtCeiling),
                     surplusInTreasury: formatDataNumber(result.surplusInTreasury, 18, 0, true),
                     marketPrice: formatDataNumber(result.marketPrice, 18, 3, true, undefined, 2),
                     redemptionPrice: formatDataNumber(result.redemptionPrice, 18, 3, true, undefined, 2),

--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -349,7 +349,9 @@ const Container = styled.div`
     }
 `
 
-const Content = styled.div``
+const Content = styled.div`
+    min-height: 100vh;
+`
 const EmptyDiv = styled.div``
 
 const AlertContainer = styled.div`


### PR DESCRIPTION
Closes #120 

## Description
- [X] Modal should close once connected 
- [X] Test token button overlapping. Change text to "Test Tokens 🪂" and reduce right padding to have even spacing
- [X] OD balance should be dollar currency formattted, commas and 2 decimals 
- [X] OD balance should be dollar currency formattted, commas and 2 decimals 
- [X] Footer is still not placed properly. The main page content height should be a minimum of screen height, so the footer never jumps up when there's no content

## Screenshots

Modal closes when connected

https://github.com/open-dollar/od-app/assets/47253537/ccdcfe5f-eacd-43c3-b6d3-6a632d346c6f

Test token button changes (note that the add token to wallet dropdown is now a little larger than the button itself to avoid the text wrapping to two lines--if you want I can just have it wrap)

https://github.com/open-dollar/od-app/assets/47253537/053d9c22-790e-4c21-a63f-9be9e17e5c96

Navbar has more responive layout when OD balance is large (note that OD is not formatted correctly in this example because I edited the text directly in the DOM to show it can be responsive with multiple #'s) 

https://github.com/open-dollar/od-app/assets/47253537/1415a649-4df8-402b-be0e-35e29000cd6d

OD balance is dollar currency formatted, commas & 2 decimals (example number is 112344)

<img width="1147" alt="input 112344" src="https://github.com/open-dollar/od-app/assets/47253537/32f914c9-9ef9-4a79-a9d2-e4334cb8cb8d">

OD balance is dollar currency formatted, commas & 2 decimals (example number is 10123)

<img width="1155" alt="input 10123" src="https://github.com/open-dollar/od-app/assets/47253537/2b81634a-20d8-470f-9c4d-a5b608d827c9">

Footer not jumping anymore (can compare with first video in this PR where footer is jumping on homepage)

https://github.com/open-dollar/od-app/assets/47253537/b00a9d57-99f3-4f37-af6c-fcc734a469db


