### PR TITLE
Issue #130: Update collateral thresholds

### DIFF
--- a/src/components/VaultBlock.tsx
+++ b/src/components/VaultBlock.tsx
@@ -46,9 +46,8 @@ const VaultBlock = ({ ...props }) => {
                             <Label>{'Risk'}</Label>
                             <Wrapper>
                                 <Circle
-                                    
                                     data-tooltip-content={`${
-                                        returnState(props.riskState) ? returnState(props.riskState) : 'No'
+                                        returnState(props.riskState) ? returnState(props.riskState) : 'Closed'
                                     } Risk`}
                                     className={
                                         returnState(props.riskState)
@@ -56,7 +55,7 @@ const VaultBlock = ({ ...props }) => {
                                             : 'dimmed'
                                     }
                                 />{' '}
-                                <div>{returnState(props.riskState) ? returnState(props.riskState) : 'No'}</div>
+                                <div>{returnState(props.riskState) ? returnState(props.riskState) : 'Closed'}</div>
                             </Wrapper>
                         </Item>
                     </Block>
@@ -138,7 +137,7 @@ const Circle = styled.div`
     &.dimmed {
         background: ${(props) => props.theme.colors.secondary};
     }
-    &.medium {
+    &.elevated {
         background: ${(props) => props.theme.colors.yellowish};
     }
     &.high {

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -143,7 +143,10 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                                         After:{' '}
                                                         <span
                                                             className={returnState(
-                                                                ratioChecker(Number(newCollateralRatio))
+                                                                ratioChecker(
+                                                                    Number(newCollateralRatio),
+                                                                    Number(collateralRatio)
+                                                                )
                                                             ).toLowerCase()}
                                                         >
                                                             {formatWithCommas(newCollateralRatio)}%

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -143,10 +143,7 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                                         After:{' '}
                                                         <span
                                                             className={returnState(
-                                                                ratioChecker(
-                                                                    Number(newCollateralRatio),
-                                                                    Number(collateralRatio)
-                                                                )
+                                                                ratioChecker(Number(newCollateralRatio))
                                                             ).toLowerCase()}
                                                         >
                                                             {formatWithCommas(newCollateralRatio)}%
@@ -165,7 +162,7 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                             data-tooltip-content={`${
                                                 singleSafe && returnState(singleSafe.riskState)
                                                     ? returnState(singleSafe.riskState)
-                                                    : 'No'
+                                                    : 'Closed'
                                             } Risk`}
                                             className={
                                                 singleSafe && returnState(singleSafe.riskState)
@@ -176,7 +173,7 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                         <MainValue>
                                             {singleSafe && returnState(singleSafe.riskState)
                                                 ? returnState(singleSafe.riskState)
-                                                : 'No'}
+                                                : 'Closed'}
                                         </MainValue>
                                     </Wrapper>
                                 </Column>
@@ -218,7 +215,9 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                     </div>
                                 ) : null}
                             </SideTitle>
-                            <SideValue>${singleSafe ? formatWithCommas(singleSafe.liquidationPrice, 2, 2) : '-'}</SideValue>
+                            <SideValue>
+                                ${singleSafe ? formatWithCommas(singleSafe.liquidationPrice, 2, 2) : '-'}
+                            </SideValue>
                         </Side>
 
                         <Side>
@@ -282,7 +281,7 @@ const RowTextWrapper = styled.div`
         &.dimmed {
             color: ${(props) => props.theme.colors.secondary};
         }
-        &.medium {
+        &.elevated {
             color: ${(props) => props.theme.colors.yellowish};
         }
         &.high {
@@ -313,7 +312,7 @@ const AfterTextWrapper = styled.span`
         &.dimmed {
             color: ${(props) => props.theme.colors.secondary};
         }
-        &.medium {
+        &.elevated {
             color: ${(props) => props.theme.colors.yellowish};
         }
         &.high {
@@ -415,7 +414,7 @@ const MainChange = styled.div`
         &.dimmed {
             color: ${(props) => props.theme.colors.secondary};
         }
-        &.medium {
+        &.elevated {
             color: ${(props) => props.theme.colors.yellowish};
         }
         &.high {
@@ -433,7 +432,7 @@ const Circle = styled.div`
     &.dimmed {
         background: ${(props) => props.theme.colors.secondary};
     }
-    &.medium {
+    &.elevated {
         background: ${(props) => props.theme.colors.yellowish};
     }
     &.high {

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -169,7 +169,7 @@ export const formatUserSafe = (
                 id: s.safeId,
                 safeHandler: s.safeHandler,
                 date: s.createdAt,
-                riskState: ratioChecker(Number(collateralRatio), Number(safetyCRatio)),
+                riskState: ratioChecker(Number(collateralRatio)),
                 collateral: s.collateral,
                 collateralType: s.collateralType,
                 collateralName: collateralBytes32[s.collateralType],
@@ -239,19 +239,17 @@ export const safeIsSafe = (totalCollateral: string, totalDebt: string, safetyPri
     return totalDebtBN.lte(totalCollateralBN.mul(safetyPriceBN).div(gebUtils.RAY))
 }
 
-export const ratioChecker = (currentLiquitdationRatio: number, minLiquidationRatio: number) => {
-    const minLiquidationRatioPercent = minLiquidationRatio * 100
-    const safestRatio = minLiquidationRatioPercent * 2.2
-    const midSafeRatio = minLiquidationRatioPercent * 1.5
-
-    if (currentLiquitdationRatio < minLiquidationRatioPercent && currentLiquitdationRatio > 0) {
-        return 4
-    } else if (currentLiquitdationRatio >= safestRatio) {
+export const ratioChecker = (currentLiquidationRatio: number) => {
+    if (currentLiquidationRatio === 0) {
+        return 0
+    } else if (currentLiquidationRatio >= 151) {
         return 1
-    } else if (currentLiquitdationRatio < safestRatio && currentLiquitdationRatio >= midSafeRatio) {
+    } else if (currentLiquidationRatio >= 137 && currentLiquidationRatio <= 150) {
         return 2
-    } else if (currentLiquitdationRatio < midSafeRatio && currentLiquitdationRatio > 0) {
+    } else if (currentLiquidationRatio >= 120 && currentLiquidationRatio <= 136) {
         return 3
+    } else if (currentLiquidationRatio > 0 && currentLiquidationRatio <= 119) {
+        return 4
     } else {
         return 0
     }
@@ -389,7 +387,7 @@ export const returnState = (state: number) => {
         case 1:
             return 'Low'
         case 2:
-            return 'Medium'
+            return 'Elevated'
         case 3:
             return 'High'
         case 4:

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -114,30 +114,24 @@ describe('utils', () => {
     })
 
     describe('#ratioChecker', () => {
-        it('returns 0', () => {
-            expect(ratioChecker(0, 1)).toEqual(0)
+        it('returns 1 for Low Risk (>= 151%)', () => {
+            expect(ratioChecker(151)).toEqual(1)
+            expect(ratioChecker(300)).toEqual(1)
         })
 
-        it('returns 1', () => {
-            expect(ratioChecker(300, 1)).toEqual(1)
-        })
-        it('returns 1', () => {
-            expect(ratioChecker(301, 1)).toEqual(1)
+        it('returns 2 for Elevated Risk (137% - 150%)', () => {
+            expect(ratioChecker(137)).toEqual(2)
+            expect(ratioChecker(150)).toEqual(2)
         })
 
-        it('returns 2', () => {
-            expect(ratioChecker(200, 1)).toEqual(2)
+        it('returns 3 for High Risk (120% - 136%)', () => {
+            expect(ratioChecker(120)).toEqual(3)
+            expect(ratioChecker(136)).toEqual(3)
         })
 
-        it('returns 2', () => {
-            expect(ratioChecker(201, 1)).toEqual(2)
-        })
-        it('returns 3', () => {
-            expect(ratioChecker(199, 1)).toEqual(3)
-        })
-
-        it('returns 3', () => {
-            expect(ratioChecker(50, 1)).toEqual(3)
+        it('returns 4 for Liquidation Risk (1% - 119%)', () => {
+            expect(ratioChecker(0)).toEqual(0)
+            expect(ratioChecker(119)).toEqual(4)
         })
     })
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -144,6 +144,14 @@ describe('utils', () => {
             expect(ratioChecker(140, 1.2)).toEqual(2)
         })
 
+        it('returns 3', () => {
+            expect(ratioChecker(120, 1.2)).toEqual(3)
+        })
+
+        it('returns 3', () => {
+            expect(ratioChecker(130, 1.2)).toEqual(3)
+        })
+
         it('returns 4', () => {
             expect(ratioChecker(50, 1.2)).toEqual(4)
         })

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -114,24 +114,42 @@ describe('utils', () => {
     })
 
     describe('#ratioChecker', () => {
-        it('returns 1 for Low Risk (>= 151%)', () => {
-            expect(ratioChecker(151)).toEqual(1)
-            expect(ratioChecker(300)).toEqual(1)
+        it('returns 0', () => {
+            expect(ratioChecker(0, 1.2)).toEqual(0)
         })
 
-        it('returns 2 for Elevated Risk (137% - 150%)', () => {
-            expect(ratioChecker(137)).toEqual(2)
-            expect(ratioChecker(150)).toEqual(2)
+        it('returns 1', () => {
+            expect(ratioChecker(300, 1.2)).toEqual(1)
+        })
+        it('returns 1', () => {
+            expect(ratioChecker(301, 1.2)).toEqual(1)
         })
 
-        it('returns 3 for High Risk (120% - 136%)', () => {
-            expect(ratioChecker(120)).toEqual(3)
-            expect(ratioChecker(136)).toEqual(3)
+        it('returns 1', () => {
+            expect(ratioChecker(200, 1.2)).toEqual(1)
         })
 
-        it('returns 4 for Liquidation Risk (1% - 119%)', () => {
-            expect(ratioChecker(0)).toEqual(0)
-            expect(ratioChecker(119)).toEqual(4)
+        it('returns 1', () => {
+            expect(ratioChecker(201, 1.2)).toEqual(1)
+        })
+        it('returns 1', () => {
+            expect(ratioChecker(199, 1.2)).toEqual(1)
+        })
+
+        it('returns 2', () => {
+            expect(ratioChecker(150, 1.2)).toEqual(2)
+        })
+
+        it('returns 2', () => {
+            expect(ratioChecker(140, 1.2)).toEqual(2)
+        })
+
+        it('returns 4', () => {
+            expect(ratioChecker(50, 1.2)).toEqual(4)
+        })
+
+        it('returns 4', () => {
+            expect(ratioChecker(30, 1.2)).toEqual(4)
         })
     })
 


### PR DESCRIPTION
Closes #130 

## Description
- The thresholds in the app are now consistent with the SVG issues
```
Low Risk 151% - 200% and above
Elevated Risk 137% - 150%
High Risk 120% - 136%
Liquidation Risk 0% - 119%
```
- Changed "No" to "Closed" when a safe is liquidated
- Updated tests

## Screenshots

<img width="1142" alt="closed" src="https://github.com/open-dollar/od-app/assets/47253537/548369f2-6a64-4ef9-8218-a8929b73b82c">

<img width="1107" alt="elevated risk" src="https://github.com/open-dollar/od-app/assets/47253537/25672b14-8331-4e71-a1a7-816085316037">

<img width="1337" alt="liquidation risk" src="https://github.com/open-dollar/od-app/assets/47253537/094e0023-519f-47e1-9858-ae9f5c37f917">

<img width="1198" alt="low risk" src="https://github.com/open-dollar/od-app/assets/47253537/a2596a2d-3ecc-4377-85e9-321a22539a6a">
