### PR TITLE
Issue #135: QA: App data polling

### DIFF
--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -101,6 +101,16 @@ const Shared = ({ children, ...rest }: Props) => {
     }, [account, geb, forceUpdateTokens, connectWalletActions])
 
     useEffect(() => {
+        const tokenDataInterval = setInterval(() => {
+            if (account && geb) {
+                connectWalletActions.fetchTokenData({ geb, user: account })
+            }
+        }, 15000)
+
+        return () => clearInterval(tokenDataInterval)
+    }, [account, geb, connectWalletActions])
+
+    useEffect(() => {
         const odBalance = connectWalletState?.tokensFetchedData.OD?.balanceE18
         const odgBalance = connectWalletState?.tokensFetchedData.ODG?.balanceE18
 


### PR DESCRIPTION
Closes #135 

## Description
- Now token data is fetched in the main body component (```<Shared>```) which is where all the vaults, auctions, & stats logic is occurring. The polling stops on unmount of ```<Shared>``` to prevent memory leaks

## Screenshots

see console message incrementing

https://github.com/open-dollar/od-app/assets/47253537/b8d131d2-bfd0-4c1a-8c03-0c703b95f815

see console message incrementing

https://github.com/open-dollar/od-app/assets/47253537/5f3485af-2a5d-432b-9e38-aa800c50a221

