### PR TITLE
Issue #133: QA: Mobile menu / dropdown

### DIFF
--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -59,7 +59,7 @@ const Nav = styled.div`
     left: 50%;
     transform: translateX(-50%);
     position: absolute;
-    @media (max-width: 1243px) {
+    @media (max-width: 767px) {
         position: unset;
         transform: initial;
     }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -90,7 +90,7 @@ const Navbar = () => {
         setPopupVisibility(!isPopupVisible)
     }
 
-    const handleClickOutside = (event: MouseEvent) => {
+    const handleClickOutsideOdRef = (event: MouseEvent) => {
         if (
             dollarRef.current &&
             !dollarRef.current.contains(event.target as Node) &&
@@ -98,6 +98,18 @@ const Navbar = () => {
             !popupRef.current.contains(event.target as Node)
         ) {
             setPopupVisibility(false)
+        }
+    }
+
+    const handleClickOutsideTestToken = (event: MouseEvent) => {
+        if (testTokenPopupRef.current && !testTokenPopupRef.current.contains(event.target as Node)) {
+            setTestTokenPopupVisibility(false)
+        }
+    }
+
+    const handleClickOutsideOdWallet = (event: MouseEvent) => {
+        if (tokenPopupRef.current && !tokenPopupRef.current.contains(event.target as Node)) {
+            setTokenPopupVisibility(false)
         }
     }
 
@@ -119,7 +131,7 @@ const Navbar = () => {
 
     const odBalance = useMemo(() => {
         const balances = connectWalletModel.tokensFetchedData
-        return formatDataNumber(balances.OD ? balances.OD.balanceE18.toString() : '0', 2, 2, false)
+        return formatDataNumber(balances.OD ? balances.OD.balanceE18.toString() : '0', 18, 2, false)
     }, [connectWalletModel.tokensFetchedData])
 
     const claimAirdropButton = async (signer: any) => {
@@ -157,11 +169,14 @@ const Navbar = () => {
     }
 
     useEffect(() => {
-        document.addEventListener('mousedown', handleClickOutside)
-
+        document.addEventListener('mousedown', handleClickOutsideOdRef)
+        document.addEventListener('mousedown', handleClickOutsideTestToken)
+        document.addEventListener('mousedown', handleClickOutsideOdWallet)
         return () => {
             // Cleanup the event listener on component unmount
-            document.removeEventListener('mousedown', handleClickOutside)
+            document.removeEventListener('mousedown', handleClickOutsideOdRef)
+            document.removeEventListener('mousedown', handleClickOutsideTestToken)
+            document.removeEventListener('mousedown', handleClickOutsideOdWallet)
         }
     }, [])
 


### PR DESCRIPTION
Closes #133 

## Description
- [X] OD balance in menu bar is showing 18 decimal version, should be formatted properly
- [X] Mobile menu is not centered.
- [X] Dropdowns should close when clicking anywhere else in the app
- [X] Claim tokens buttons is missing from mobile menu

## Screenshots

OD balance when 3810 OD

<img width="1087" alt="3,810" src="https://github.com/open-dollar/od-app/assets/47253537/5458c947-b2a7-4dde-bcc4-ad27b63fcce7">


OD balance when 10 OD

<img width="449" alt="10 od" src="https://github.com/open-dollar/od-app/assets/47253537/a3039352-14da-404b-9743-23a37d48b16d">


OD balance when 10418.29

<img width="685" alt="10,412 29" src="https://github.com/open-dollar/od-app/assets/47253537/8bf77b73-ba9f-4e29-b9a8-528460583423">

Dropdowns close when clicking outside

https://github.com/open-dollar/od-app/assets/47253537/4ab2b905-b20e-4f9f-aa80-274930a23273

Mobile menu centered, claim tokens button added to mobile menu


https://github.com/open-dollar/od-app/assets/47253537/457ddb7d-be01-4167-9f93-8f59a4cfb524



