### PR TITLE
Issue #136: QA: New vault debt minimum

### DIFF
--- a/src/hooks/useSafe.ts
+++ b/src/hooks/useSafe.ts
@@ -301,6 +301,9 @@ export function useSafeInfo(type: SafeTypes = 'create') {
         if (leftInputBN.isZero()) {
             error = error ?? `Enter ${collateralName} Amount`
         }
+        if (rightInputBN.isZero()) {
+            error = error ?? 'OD borrowed cannot be zero'
+        }
     }
 
     if (type !== 'create') {
@@ -408,8 +411,8 @@ export function useInputsHandlers(): {
 
     const onLeftInput = useCallback(
         (typedValue: string) => {
-            if (typedValue === ".") {
-                typedValue = "0.";
+            if (typedValue === '.') {
+                typedValue = '0.'
             }
             safeActions.setSafeData({
                 ...safeData,
@@ -420,8 +423,8 @@ export function useInputsHandlers(): {
     )
     const onRightInput = useCallback(
         (typedValue: string) => {
-            if (typedValue === ".") {
-                typedValue = "0.";
+            if (typedValue === '.') {
+                typedValue = '0.'
             }
             safeActions.setSafeData({
                 ...safeData,


### PR DESCRIPTION
Closes #136 

## Description
- Now creating a vault has the same validation check that deposit and borrow has--ensuring OD borrowed > 0

for the record we added this logic modifying a vault in this PR: https://github.com/open-dollar/od-app/pull/100/files 

## Screenshots

before fix, without validation

<img width="921" alt="before vault fix" src="https://github.com/open-dollar/od-app/assets/47253537/35472792-4096-40d8-82ee-229f1b3b1c5b">

after fix, with validation

<img width="998" alt="after vault fix" src="https://github.com/open-dollar/od-app/assets/47253537/d64d72ea-1fed-4fba-b61f-ed517efe5d74">

can create a vault once OD borrowed

<img width="923" alt="better" src="https://github.com/open-dollar/od-app/assets/47253537/e5562e98-1f31-41bf-abcd-c32ba27df06c">



