### PR TITLE
Issue #144: Poll Stats and Vault data

### DIFF
--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -100,6 +100,7 @@ const Shared = ({ children, ...rest }: Props) => {
         }
     }, [account, geb, forceUpdateTokens, connectWalletActions])
 
+    // Get latest token prices every 15 seconds
     useEffect(() => {
         const tokenDataInterval = setInterval(() => {
             if (account && geb) {
@@ -108,6 +109,21 @@ const Shared = ({ children, ...rest }: Props) => {
         }, 15000)
 
         return () => clearInterval(tokenDataInterval)
+    }, [account, geb, connectWalletActions])
+
+    // Get latest vault data every 1 minute
+    useEffect(() => {
+        const statsInterval = setInterval(() => {
+            if (account && geb && connectWalletState.tokensData) {
+                safeActions.fetchUserSafes({
+                    address: account as string,
+                    geb,
+                    tokensData: connectWalletState.tokensData,
+                })
+            }
+        }, 60000)
+
+        return () => clearInterval(statsInterval)
     }, [account, geb, connectWalletActions])
 
     useEffect(() => {

--- a/src/containers/Vaults/Stats.js
+++ b/src/containers/Vaults/Stats.js
@@ -1,16 +1,13 @@
 'use client'
 
-import { useEffect, useContext } from 'react'
-import { SYSTEMSTATE_QUERY } from '../../utils/queries'
+import { useEffect } from 'react'
+import { SYSTEMSTATE_QUERY } from '~/utils/queries'
 import { useQuery } from '@apollo/client'
-import { formatNumber, getCollateralRatio } from '../../utils/helpers'
-import { useStats } from '../../hooks/useStats'
+import { formatNumber, getCollateralRatio } from '~/utils/helpers'
+import { useStats } from '~/hooks/useStats'
 import styled from 'styled-components'
-import GridContainer from '~/components/GridContainer'
 import Loader from '~/components/Loader'
 import LinkButton from '~/components/LinkButton'
-
-// import { FaExternalLinkSquareAlt } from 'react-icons/fa';
 
 const Stats = () => {
     const { loading, data } = useQuery(SYSTEMSTATE_QUERY)

--- a/src/containers/Vaults/index.tsx
+++ b/src/containers/Vaults/index.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 
 import { useStoreState, useStoreActions } from '~/store'
 import { useActiveWeb3React } from '~/hooks'
-import Stats from './Stats'
 import useGeb from '~/hooks/useGeb'
 import Accounts from './Accounts'
 import VaultList from './VaultList'


### PR DESCRIPTION
Closes #144 

## Description
- Fetch safe data every 60 seconds like how we're fetching token data every 15 seconds
- Cleaned up some components

What stats data do we want to fetch every 60 seconds? I noticed that the <Stats> component and even the StatsProvider isn't currently being accessed. Do we want to call fetchDataAnalytics every 60 seconds?

## Screenshots

https://github.com/open-dollar/od-app/assets/47253537/a1f0bedd-7cbb-4f9a-a423-d27c50d0b126

