### PR TITLE
Fix arbitrum goerli config

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -68,10 +68,10 @@ export async function checkAndSwitchMetamaskNetwork() {
                     params: [
                         {
                             chainId: `0x66EED`,
-                            chainName: 'Arbitrum Goerli Testnet',
+                            chainName: 'Arbitrum Goerli',
                             nativeCurrency: {
-                                name: 'ETH',
-                                symbol: 'ETH',
+                                name: 'AGOR',
+                                symbol: 'AGOR',
                                 decimals: 18,
                             },
                             rpcUrls: ['https://goerli-rollup.arbitrum.io/rpc'],


### PR DESCRIPTION
## Description
- Arbitrum goerli network should have AGOR as its currency (arbitrum one is correctly ETH in the app) and its name should be Arbitrum Goerli

## Screenshot

No warning when adding network now

<img width="1290" alt="fixed name" src="https://github.com/open-dollar/od-app/assets/47253537/12df85cc-9575-456d-ad74-bb8a384b11e0">
