### PR TITLE
Issue #158: Debt floor, collateral validation

### DIFF
--- a/src/hooks/useSafe.ts
+++ b/src/hooks/useSafe.ts
@@ -245,9 +245,6 @@ export function useSafeInfo(type: SafeTypes = 'create') {
             error =
                 error ?? `Please enter the amount of ${collateralName} to be deposited or amount of OD to be borrowed`
         }
-        if (rightInputBN.isZero()) {
-            error = error ?? 'OD borrowed cannot be zero'
-        }
     }
 
     if (type === 'repay_withdraw') {
@@ -300,9 +297,6 @@ export function useSafeInfo(type: SafeTypes = 'create') {
     if (type === 'create') {
         if (leftInputBN.isZero()) {
             error = error ?? `Enter ${collateralName} Amount`
-        }
-        if (rightInputBN.isZero()) {
-            error = error ?? 'OD borrowed cannot be zero'
         }
     }
 


### PR DESCRIPTION
Closes #158 

## Description
- [X] When opening a new vault- you must meet the debtFloor, which is 1 OD minted
- [X] When modifying a vault (Deposit & Borrow or Repay & Withdraw) the resulting debt must also meet the debtFloor. The form input is allowed to be 0 OD in this case, since a vault already contains OD.
- [] Closing a vault is an exception to the rules above, therefore debt can be 0 OD

Why would debt be 0 OD when closing a vault? We can't close the vault unless enough collateral is deposited to meet the collateralization ratio. Otherwise we can just pay back the debt and the vault will be closed.

example:

<img width="921" alt="closing vault" src="https://github.com/open-dollar/od-app/assets/47253537/a366d871-c759-4118-b0cd-86307f1a14dc">


## Screenshots

Creating a vault

<img width="1159" alt="create vault validation" src="https://github.com/open-dollar/od-app/assets/47253537/8c7e2f99-088e-415d-bba7-8ffe2e298d77">

Creating a vault

<img width="1068" alt="create vault validation 2" src="https://github.com/open-dollar/od-app/assets/47253537/d3a5d20c-19c0-4161-be06-689fdeeedced">

Deposit and borrow

<img width="982" alt="deposit and borrow still validates" src="https://github.com/open-dollar/od-app/assets/47253537/a3084471-ddc0-4e3e-9026-36651dad9c35">

Repay and withdraw 

<img width="1071" alt="repay and withdraw too much debt" src="https://github.com/open-dollar/od-app/assets/47253537/e05c13f8-4bbb-484d-90d9-62d534c22ce1">

