### PR TITLE
Issue #163: Fix create vault tooltips

### DIFF
--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -338,7 +338,12 @@ const CreateVault = ({
                             </Button>
                         )}
                     </Flex>
-                    <ReactTooltip id="tooltip-create-vault" variant="light" data-effect="solid" />
+                    <ReactTooltip
+                        style={{ zIndex: 99 }}
+                        id="tooltip-create-vault"
+                        variant="light"
+                        data-effect="solid"
+                    />
                 </Content>
             </InnerContent>
         </>


### PR DESCRIPTION
Closes #163 

## Description
- Adjusts the z-index of tooltips on create vault screen to 99

## Screenshots

https://github.com/open-dollar/od-app/assets/47253537/d7917e24-c289-45c5-92a4-1e478589303d

