### PR TITLE
Issue #165: Global Stats 

### DIFF
--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -46,6 +46,7 @@ import {
 import LiquidateSafeModal from '~/components/Modals/LiquidateSafeModal'
 import Footer from '~/components/Footer'
 import checkSanctions from '~/services/checkSanctions'
+import Stats from '~/containers/Vaults/Stats'
 
 interface Props {
     children: ReactNode
@@ -60,6 +61,7 @@ const Shared = ({ children, ...rest }: Props) => {
     const previousAccount = usePrevious(account)
 
     const location = useLocation()
+    const { pathname } = location
     const tokensData = geb?.tokenList
     const coinTokenContract = useTokenContract(getTokenList(ETH_NETWORK).OD.address)
     const protTokenContract = useTokenContract(getTokenList(ETH_NETWORK).ODG.address)
@@ -313,7 +315,6 @@ const Shared = ({ children, ...rest }: Props) => {
             <EmptyDiv>
                 <Navbar />
             </EmptyDiv>
-
             {SYSTEM_STATUS && SYSTEM_STATUS.toLowerCase() === 'shutdown' ? (
                 <AlertContainer>
                     <AlertLabel type="danger" text={t('shutdown_text')} />
@@ -327,6 +328,7 @@ const Shared = ({ children, ...rest }: Props) => {
             <EmptyDiv>
                 <CookieBanner />
             </EmptyDiv>
+            {pathname === '/' ? <Stats /> : <></>}
             <ImagePreloader />
             <EmptyDiv>
                 <Footer />

--- a/src/containers/Vaults/Stats.js
+++ b/src/containers/Vaults/Stats.js
@@ -1,259 +1,170 @@
 'use client'
 
-import { useEffect } from 'react'
-import { SYSTEMSTATE_QUERY } from '~/utils/queries'
-import { useQuery } from '@apollo/client'
-import { formatNumber, getCollateralRatio } from '~/utils/helpers'
-import { useStats } from '~/hooks/useStats'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import Loader from '~/components/Loader'
-import LinkButton from '~/components/LinkButton'
+import { fetchAnalyticsData } from '@opendollar/sdk/lib/virtual/virtualAnalyticsData'
+import {
+    formatDataNumber,
+} from '~/utils'
+import useGeb from '~/hooks/useGeb'
+import { fetchPoolData } from '@opendollar/sdk'
+import { ethers } from 'ethers'
 
 const Stats = () => {
-    const { loading, data } = useQuery(SYSTEMSTATE_QUERY)
-    const stats = useStats()
+    const geb = useGeb()
+    const [state, setState] = useState({
+        totalVaults: '',
+        wETHBalance: '',
+        odBalance: '',
+    })
 
     useEffect(() => {
-        if (data && stats) {
-            stats.setStandardStats(
-                data.systemStates[0].safeCount,
-                data.systemStates[0].totalActiveSafeCount,
-                data.systemStates[0].globalDebt,
-                data.systemStates[0].currentRedemptionPrice.value,
-                data.redemptionRates[0].annualizedRate,
-                data.collateralPrices[0].collateral.totalCollateral,
-                data.collateralPrices[0].collateral.currentPrice.value,
-                data.dailyStats[0].marketPriceUsd,
-                data.safes[0].collateralType.currentPrice.collateral.liquidationCRatio,
-                data.safes[0].collateralType.currentPrice.liquidationPrice
-            )
+        async function fetchData() {
+            if (geb) {
+                try {
+                    const [poolData, analyticsData] = await Promise.all([fetchPoolData(geb), fetchAnalyticsData(geb)])
+                    setState((prevState) => ({
+                        ...prevState,
+                        totalVaults: analyticsData.totalVaults,
+                        wETHBalance: formatDataNumber(poolData.WETH_balance, 18, 2, false),
+                        odBalance: formatDataNumber(poolData.OD_balance, 18, 2, false),
+                    }))
+                } catch (error) {
+                    console.error('Error fetching data:', error)
+                }
+            }
         }
-    }, [data])
 
-    const Text = ({ children }) => <p>{children}</p>
-    const SimpleGrid = ({ children }) => <div>{children}</div>
-    const ChakraLink = ({ children }) => <div>{children}</div>
+        fetchData()
+    }, [geb])
 
     return (
-        <Container>
+        <ComponentContainer>
             <Header>
-                <Title>Global Stats</Title>
+                <Title>Stats</Title>
                 <LinkWrapper>
-                    <LinkButton
-                        id="stats"
-                        text={'Click for more stats..'}
-                        url={`https://stats.opendollar.com/`}
-                        color={'blueish'}
-                        isExternal
-                    />
+                    <a
+                        style={{ color: '#1499DA', fontWeight: '600', fontSize: '14px' }}
+                        href="https://stats.opendollar.com/"
+                        target="_blank"
+                    >
+                        View All Stats
+                    </a>
                 </LinkWrapper>
             </Header>
-            {!loading ? (
-                <>
-                    <Wrapper>
-                        <Container
-                            direction="column"
-                            mr={{ lg: '2rem', sm: 0 }}
-                            alignItems="left"
-                            justifyContent="center"
+            <Wrapper>
+                <Container>
+                    <StatItem>
+                        <TextHeader>Total Vaults</TextHeader>
+                        <Text
+                            fontSize={{ lg: '28px', sm: '18px' }}
+                            mb=".5rem"
+                            background="linear-gradient(to right, #41c1d0, #1a6c51)"
+                            backgroundClip="text"
+                            fontWeight="extrabold"
                         >
-                            <Text
-                                fontSize={{ lg: '28px', sm: '18px' }}
-                                mb=".5rem"
-                                background="linear-gradient(to right, #41c1d0, #1a6c51)"
-                                backgroundClip="text"
-                                fontWeight="extrabold"
-                            >
-                                {new Intl.NumberFormat('en-US', {
-                                    style: 'decimal',
-                                    minimumFractionDigits: 0,
-                                }).format(Number(stats.safeCount))}
-                            </Text>
-                            <Text fontSize={{ lg: '14px', sm: '12px' }} fontWeight="bold">
-                                Total Vaults
-                            </Text>
-                        </Container>
-                        <Container direction="column" alignItems="left" justifyContent="center">
-                            <Text
-                                fontSize={{ lg: '28px', sm: '18px' }}
-                                mb=".5rem"
-                                background="linear-gradient(to right, #41c1d0, #1a6c51)"
-                                backgroundClip="text"
-                                fontWeight="extrabold"
-                            >
-                                {stats.activeSafesCount}
-                            </Text>
-                            <Text fontSize={{ lg: '14px', sm: '12px' }} fontWeight="bold">
-                                Active Vaults
-                            </Text>
-                        </Container>
-                        <Container
-                            direction="column"
-                            mr={{ lg: '2rem', sm: 0 }}
-                            alignItems="left"
-                            justifyContent="center"
+                            {state?.totalVaults}
+                        </Text>
+                    </StatItem>
+                </Container>
+                <Container>
+                    <StatItem>
+                        <TextHeader>ETH Collateral</TextHeader>
+                        <Text
+                            fontSize={{ lg: '28px', sm: '18px' }}
+                            mb=".5rem"
+                            background="linear-gradient(to right, #41c1d0, #1a6c51)"
+                            backgroundClip="text"
+                            fontWeight="extrabold"
                         >
-                            <Text
-                                fontSize={{ lg: '28px', sm: '18px' }}
-                                mb=".5rem"
-                                background="linear-gradient(to right, #41c1d0, #1a6c51)"
-                                backgroundClip="text"
-                                fontWeight="extrabold"
-                            >
-                                ${' '}
-                                {new Intl.NumberFormat('en-US', {
-                                    style: 'decimal',
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2,
-                                }).format(Number(formatNumber(stats.collateralPrice)))}{' '}
-                                USD
-                            </Text>
-                            <Text fontSize={{ lg: '14px', sm: '12px' }} fontWeight="bold">
-                                ETH Price
-                            </Text>
-                        </Container>
-                        <Container
-                            direction="column"
-                            mr={{ lg: '2rem', sm: 0 }}
-                            alignItems="left"
-                            justifyContent="center"
+                            {state?.wETHBalance} ETH
+                        </Text>
+                    </StatItem>
+                </Container>
+                <Container>
+                    <StatItem>
+                        <TextHeader>Minted OD Debt</TextHeader>
+                        <Text
+                            fontSize={{ lg: '28px', sm: '18px' }}
+                            mb=".5rem"
+                            background="linear-gradient(to right, #41c1d0, #1a6c51)"
+                            backgroundClip="text"
+                            fontWeight="extrabold"
                         >
-                            <Text
-                                fontSize={{ lg: '28px', sm: '18px' }}
-                                mb=".5rem"
-                                background="linear-gradient(to right, #41c1d0, #1a6c51)"
-                                backgroundClip="text"
-                                fontWeight="extrabold"
-                            >
-                                {new Intl.NumberFormat('en-US', {
-                                    style: 'decimal',
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2,
-                                }).format(Number(formatNumber(stats.globalCollateral)))}
-                            </Text>
-                            <Text fontSize={{ lg: '14px', sm: '12px' }} fontWeight="bold">
-                                ETH Collateral
-                            </Text>
-                        </Container>
-                        <Container
-                            direction="column"
-                            mr={{ lg: '2rem', sm: 0 }}
-                            alignItems="left"
-                            justifyContent="center"
-                        >
-                            <Text
-                                fontSize={{ lg: '28px', sm: '18px' }}
-                                mb=".5rem"
-                                background="linear-gradient(to right, #41c1d0, #1a6c51)"
-                                backgroundClip="text"
-                                fontWeight="extrabold"
-                            >
-                                {new Intl.NumberFormat('en-US', {
-                                    style: 'decimal',
-                                    minimumFractionDigits: 0,
-                                }).format(Number(formatNumber(stats.globalDebt, 0, true)))}
-                            </Text>
-                            <Text fontSize={{ lg: '14px', sm: '12px' }} fontWeight="bold">
-                                Minted OD Debt
-                            </Text>
-                        </Container>
+                            {state?.odBalance} OD
+                        </Text>
+                    </StatItem>
+                </Container>
 
-                        <Container
-                            direction="column"
-                            mr={{ lg: '2rem', sm: 0 }}
-                            alignItems="left"
-                            justifyContent="center"
+                <Container>
+                    <StatItem>
+                        <TextHeader>Collateral Ratio</TextHeader>
+                        <Text
+                            fontSize={{ lg: '28px', sm: '18px' }}
+                            mb=".5rem"
+                            background="linear-gradient(to right, #41c1d0, #1a6c51)"
+                            backgroundClip="text"
+                            fontWeight="extrabold"
                         >
-                            <Text
-                                fontSize={{ lg: '28px', sm: '18px' }}
-                                mb=".5rem"
-                                background="linear-gradient(to right, #41c1d0, #1a6c51)"
-                                backgroundClip="text"
-                                fontWeight="extrabold"
-                            >
-                                {getCollateralRatio(
-                                    stats.globalCollateral,
-                                    stats.globalDebt,
-                                    stats.liquidationPrice,
-                                    stats.liquidationCRatio
-                                )}
-                                %
-                            </Text>
-                            <Text fontSize={{ lg: '14px', sm: '12px' }} fontWeight="bold">
-                                Collateral Ratio
-                            </Text>
-                        </Container>
-
-                        <Container
-                            direction="column"
-                            mr={{ lg: '2rem', sm: 0 }}
-                            alignItems="left"
-                            justifyContent="center"
-                        >
-                            <Text
-                                fontSize={{ lg: '28px', sm: '18px' }}
-                                mb=".5rem"
-                                background="linear-gradient(to right, #41c1d0, #1a6c51)"
-                                backgroundClip="text"
-                                fontWeight="extrabold"
-                            >
-                                $ {Number(formatNumber(stats.raiRedemptionPrice)).toLocaleString('en-US')} USD
-                            </Text>
-                            <Text fontSize={{ lg: '14px', sm: '12px' }} fontWeight="bold">
-                                OD Redemption Price
-                            </Text>
-                        </Container>
-                        <Container
-                            direction="column"
-                            mr={{ lg: '2rem', sm: 0 }}
-                            alignItems="left"
-                            justifyContent="center"
-                        >
-                            <Text
-                                fontSize={{ lg: '28px', sm: '18px' }}
-                                mb=".5rem"
-                                background="linear-gradient(to right, #41c1d0, #1a6c51)"
-                                backgroundClip="text"
-                                fontWeight="extrabold"
-                            >
-                                {new Intl.NumberFormat('en-US', {
-                                    style: 'decimal',
-                                    minimumFractionDigits: 3,
-                                }).format(Number((stats.raiRedemptionRate - 1) * 100))}{' '}
-                                %
-                            </Text>
-                            <Text fontSize={{ lg: '14px', sm: '12px' }} fontWeight="bold">
-                                OD Redemption Rate APY
-                            </Text>
-                        </Container>
-                    </Wrapper>
-                </>
-            ) : (
-                <Loader />
-            )}
-        </Container>
+                            {/*{getCollateralRatio(*/}
+                            {/*    stats?.globalCollateral,*/}
+                            {/*    stats?.globalDebt,*/}
+                            {/*    stats?.liquidationPrice,*/}
+                            {/*    stats?.liquidationCRatio*/}
+                            {/*)}*/}%
+                        </Text>
+                    </StatItem>
+                </Container>
+            </Wrapper>
+        </ComponentContainer>
     )
 }
 export default Stats
 
+const Text = styled.div`
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 21px;
+`
+
+const StatItem = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: end;
+    @media (max-width: 767px) {
+        align-items: start;
+    }
+`
+
+const TextHeader = styled.div`
+    font-size: 13px;
+    color: ${(props) => props.theme.colors.secondary};
+    letter-spacing: -0.09px;
+    line-height: 21px;
+    @media (max-width: 767px) {
+        font-size: ${(props) => props.theme.font.small};
+    }
+`
+
 const Header = styled.div`
-    margin-bottom: 56px;
+    margin-bottom: 16px;
     display: flex;
 `
 
 const Title = styled.div`
     font-weight: 700;
-    font-size: 34px;
-    line-height: 41px;
+    font-size: 20px;
+    line-height: 24px;
 `
 
 const Wrapper = styled.div`
-    display: grid;
-    grid-template-columns: repeat(8, 1fr);
-    padding: 15px;
+    display: flex;
+    background: #002b40;
+    width: 100%;
     margin-bottom: 24px;
+    justify-content: space-between;
     border-radius: 15px;
-    background: ${(props) => props.theme.colors.colorSecondary};
 `
 
 const LinkWrapper = styled.div`
@@ -261,22 +172,17 @@ const LinkWrapper = styled.div`
     margin-left: auto;
 `
 
+const ComponentContainer = styled.div`
+    max-width: 880px;
+    margin: 20px auto;
+    padding: 0 15px;
+`
+
 const Container = styled.div`
     max-width: 880px;
-    margin: 80px auto;
+    margin: 16px;
     padding: 0 15px;
     @media (max-width: 767px) {
         margin: 50px auto;
     }
-`
-
-const Inner = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-`
-
-const LabelContainer = styled.div`
-    max-width: ${(props) => props.theme.global.gridMaxWidth};
-    margin: 0 auto 20px auto;
 `

--- a/src/containers/Vaults/VaultDetails.tsx
+++ b/src/containers/Vaults/VaultDetails.tsx
@@ -12,6 +12,7 @@ import VaultHeader from './VaultHeader'
 import useGeb from '~/hooks/useGeb'
 import gebManager from '~/utils/gebManager'
 import { ethers } from 'ethers'
+import Stats from '~/containers/Vaults/Stats'
 
 const VaultDetails = ({ ...props }) => {
     const geb = useGeb()
@@ -98,20 +99,25 @@ const VaultDetails = ({ ...props }) => {
     const isLoading = !(liquidationData && singleSafe?.collateralName)
 
     return (
-        <Container>
-            {!isOwner ? (
-                <LabelContainer>
-                    <AlertLabel isBlock={false} text={t('managed_safe_warning')} type="warning" />
-                </LabelContainer>
-            ) : null}
-            <VaultHeader safeId={safeId} isModifying={isDeposit || isWithdraw} isDeposit={isDeposit} />
+        <>
+            <Container>
+                {!isOwner ? (
+                    <LabelContainer>
+                        <AlertLabel isBlock={false} text={t('managed_safe_warning')} type="warning" />
+                    </LabelContainer>
+                ) : null}
+                <VaultHeader safeId={safeId} isModifying={isDeposit || isWithdraw} isDeposit={isDeposit} />
 
-            {!isLoading && <VaultStats isModifying={isDeposit || isWithdraw} isDeposit={isDeposit} isOwner={isOwner} />}
+                {!isLoading && (
+                    <VaultStats isModifying={isDeposit || isWithdraw} isDeposit={isDeposit} isOwner={isOwner} />
+                )}
 
-            {(isDeposit || isWithdraw) && !isLoading ? (
-                <ModifyVault vaultId={safeId} isDeposit={isDeposit} isOwner={isOwner} />
-            ) : null}
-        </Container>
+                {(isDeposit || isWithdraw) && !isLoading ? (
+                    <ModifyVault vaultId={safeId} isDeposit={isDeposit} isOwner={isOwner} />
+                ) : null}
+            </Container>
+            <Stats />
+        </>
     )
 }
 


### PR DESCRIPTION
Closes #165 

## Description
- Edited our old stats component to match the Figma designs (though I changed safes -> vaults and took out some sections that we don't have stats for)
- Added the component to the index route and the vaults page

Currently the collateral ratio section is empty--what numbers do we want to use for these? The hai team was using  stats?.globalCollateral, stats?.globalDebt, stats?.liquidationPrice, and stats?.liquidationCRatio to calculate it. We have globalDebt via fetchAnalyticsData but not sure about the others

Also, can't merge this until the SDK is updated to have fetchPoolData

## Screenshots

Index page desktop

<img width="1460" alt="index page desktop" src="https://github.com/open-dollar/od-app/assets/47253537/4d7df532-3255-49a6-bdb0-919a6212faba">

Vaults page desktop

<img width="1210" alt="vaults page desktop" src="https://github.com/open-dollar/od-app/assets/47253537/e7ea2a05-3e27-477b-b0fe-375aacad5c08">

Index page mobile

<img width="457" alt="index page mobile" src="https://github.com/open-dollar/od-app/assets/47253537/c29a64aa-6d40-4467-b0a5-75047257cc5e">

Vaults page mobile

<img width="466" alt="vaults page mobile" src="https://github.com/open-dollar/od-app/assets/47253537/aefa9b3a-5b0c-4d8a-96bf-2f4faefcab62">

Responsive

https://github.com/open-dollar/od-app/assets/47253537/dfca7956-e546-4c55-9caa-a78e21cf61dc




