### PR TITLE
Issue #172: Add token symbol to total locked

### DIFF
--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -306,7 +306,7 @@ const Analytics = () => {
                             ), // Borrow rate
                             formatDataNumber(value?.debtAmount?.toString() || '0', 18, 2, true, true), // Debt Amount
                             transformToWadPercentage(value?.debtAmount?.toString(), value?.debtCeiling?.toString()), // Debt Utilization
-                            formatDataNumber(value?.lockedAmount?.toString() || '0', 18, 2, false, true), // Amount locked
+                            formatDataNumber(value?.lockedAmount?.toString() || '0', 18, 2, false, true) + ' ' + key, // Amount locked
                             formatDataNumber(
                                 multiplyWad(value?.lockedAmount?.toString(), value?.currentPrice?.toString()) || '0',
                                 18,

--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -317,7 +317,9 @@ const Analytics = () => {
                                 ), // Borrow rate
                                 formatDataNumber(value?.debtAmount?.toString() || '0', 18, 2, true, true), // Debt Amount
                                 transformToWadPercentage(value?.debtAmount?.toString(), value?.debtCeiling?.toString()), // Debt Utilization
-                                formatDataNumber(value?.lockedAmount?.toString() || '0', 18, 2, false, true), // Amount locked
+                                formatDataNumber(value?.lockedAmount?.toString() || '0', 18, 2, false, true) +
+                                    ' ' +
+                                    key, // Amount locked
                                 formatDataNumber(
                                     multiplyWad(value?.lockedAmount?.toString(), value?.currentPrice?.toString()) ||
                                         '0',


### PR DESCRIPTION
Closes #172 

## Description
- Token symbol now beside amount locked for each collateral

## Screenshots

<img width="1161" alt="Screenshot 2023-10-25 at 1 15 28 PM" src="https://github.com/open-dollar/od-app/assets/47253537/b491ef16-77f4-4858-ade0-5d3abfed7008">