### PR TITLE
Issue #168: Add SVG

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@ethersproject/providers": "5.4.5",
         "@gnosis.pm/safe-apps-web3-react": "^0.6.0",
         "@opendollar/sdk": "^1.5.6-rc.2",
-        "@opendollar/svg-playground": "1.0.0",
+        "@opendollar/svg-generator": "1.0.0",
         "@react-spring/web": "^9.7.3",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.3.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "@ethersproject/providers": "5.4.5",
         "@gnosis.pm/safe-apps-web3-react": "^0.6.0",
         "@opendollar/sdk": "^1.5.6-rc.2",
+        "@opendollar/svg-playground": "1.0.0",
         "@react-spring/web": "^9.7.3",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.3.2",

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -9,7 +9,7 @@ import { formatNumber, formatWithCommas, getRatePercentage, ratioChecker, return
 import { useStoreState } from '~/store'
 import { Tooltip as ReactTooltip } from 'react-tooltip'
 //@ts-ignore
-import { renderSvg } from '@opendollar/svg-playground'
+import { renderSvg } from '@opendollar/svg-generator'
 
 const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposit: boolean; isOwner: boolean }) => {
     const { t } = useTranslation()
@@ -47,19 +47,20 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
 
     const statsForSVG = {
         vaultID: singleSafe?.id,
-        stabilityFee:  Math.floor(Number(getRatePercentage(singleSafe?.totalAnnualizedStabilityFee ? singleSafe?.totalAnnualizedStabilityFee : '0', 2))).toString() + '%',
+        stabilityFee:
+            Math.floor(
+                Number(
+                    getRatePercentage(
+                        singleSafe?.totalAnnualizedStabilityFee ? singleSafe?.totalAnnualizedStabilityFee : '0',
+                        2
+                    )
+                )
+            ).toString() + '%',
         debtAmount: formatWithCommas(totalDebt) + ' OD',
         collateralAmount: formatWithCommas(collateral) + ' ' + collateralName,
         collateralizationRatio: Number(singleSafe?.collateralRatio),
-        safetyRatio: Number(
-            safeState.liquidationData!.collateralLiquidationData[
-                collateralName].safetyCRatio
-        ),
-        liqRatio: Number(
-            safeState.liquidationData!.collateralLiquidationData[
-                collateralName
-                ].liquidationCRatio
-        ),
+        safetyRatio: Number(safeState.liquidationData!.collateralLiquidationData[collateralName].safetyCRatio),
+        liqRatio: Number(safeState.liquidationData!.collateralLiquidationData[collateralName].liquidationCRatio),
     }
 
     useEffect(() => {
@@ -92,16 +93,34 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                 <Left>
                     <InnerLeft className="main">
                         <Main>
-                                <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%', position: 'relative', overflow: 'scroll'}}>
-                                    <div style={{maxWidth: '100%', height: 'auto', border: '1px solid #00374E', borderRadius: '0px'}} dangerouslySetInnerHTML={{__html: svg}}></div>
-                                </div>
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    width: '100%',
+                                    height: '100%',
+                                    position: 'relative',
+                                    overflow: 'scroll',
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        maxWidth: '100%',
+                                        height: 'auto',
+                                        border: '1px solid #00374E',
+                                        borderRadius: '0px',
+                                    }}
+                                    dangerouslySetInnerHTML={{ __html: svg }}
+                                ></div>
+                            </div>
                         </Main>
                     </InnerLeft>
                 </Left>
 
                 <Right>
                     <Inner>
-                        <Side style={{borderTop: '1px solid #00587E', paddingTop: '8px'}}>
+                        <Side style={{ borderTop: '1px solid #00587E', paddingTop: '8px' }}>
                             <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('debt_owed_tip')}>
                                 <Info size="16" />
                             </InfoIcon>
@@ -156,10 +175,39 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                             <SideTitle>
                                 Collateral Ratio (min {collateralRatio}%)
                                 <div>
-                                    <span style={{color: '#FCBF3B', fontSize: '12px', fontWeight:'400', lineHeight: '15.6px', opacity: '60%'}}>Safety: {Number(safeState.liquidationData!.collateralLiquidationData[
-                                        collateralName].safetyCRatio) * 100}%</span> &nbsp;
-                                    <span style={{color: '#E45200', fontSize: '12px', fontWeight:'400', lineHeight: '15.6px', opacity: '60%'}}>Minimum: {Number(safeState.liquidationData!.collateralLiquidationData[
-                                        collateralName].liquidationCRatio) * 100}%</span>
+                                    <span
+                                        style={{
+                                            color: '#FCBF3B',
+                                            fontSize: '12px',
+                                            fontWeight: '400',
+                                            lineHeight: '15.6px',
+                                            opacity: '60%',
+                                        }}
+                                    >
+                                        Safety:{' '}
+                                        {Number(
+                                            safeState.liquidationData!.collateralLiquidationData[collateralName]
+                                                .safetyCRatio
+                                        ) * 100}
+                                        %
+                                    </span>{' '}
+                                    &nbsp;
+                                    <span
+                                        style={{
+                                            color: '#E45200',
+                                            fontSize: '12px',
+                                            fontWeight: '400',
+                                            lineHeight: '15.6px',
+                                            opacity: '60%',
+                                        }}
+                                    >
+                                        Minimum:{' '}
+                                        {Number(
+                                            safeState.liquidationData!.collateralLiquidationData[collateralName]
+                                                .liquidationCRatio
+                                        ) * 100}
+                                        %
+                                    </span>
                                 </div>
                                 {modified ? (
                                     <div className="sideNote">
@@ -280,7 +328,6 @@ const InnerLeft = styled.div`
     height: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: center;
 `
 
 const Inner = styled.div`
@@ -328,16 +375,17 @@ const DollarValue = styled.div`
 
 const Side = styled.div`
     display: flex;
-    align-items: flex-start;
-    margin-bottom: 20px;
     &:last-child {
         margin-bottom: 0;
     }
-  border-bottom: 1px solid #00587E;
-  padding-bottom: 8px;
-  svg {
-    border: 1px solid #00374E;
-  }
+    border-bottom: 1px solid #00587e;
+    padding-bottom: 4px;
+    @media (max-width: 767px) {
+        padding-top: 4px;
+    }
+    svg {
+        border: 1px solid #00374e;
+    }
 `
 
 const SideTitle = styled.div`
@@ -368,7 +416,7 @@ const InfoIcon = styled.div`
         fill: ${(props) => props.theme.colors.secondary};
         color: ${(props) => props.theme.colors.foreground};
         position: relative;
-        top: 2px;
+        top: 4px;
         margin-right: 5px;
     }
 `

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -47,7 +47,7 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
 
     const statsForSVG = {
         vaultID: singleSafe?.id,
-        stabilityFee:  getRatePercentage(singleSafe?.totalAnnualizedStabilityFee ? singleSafe?.totalAnnualizedStabilityFee : '0', 2) + '%',
+        stabilityFee:  Math.floor(Number(getRatePercentage(singleSafe?.totalAnnualizedStabilityFee ? singleSafe?.totalAnnualizedStabilityFee : '0', 2))).toString() + '%',
         debtAmount: formatWithCommas(totalDebt) + ' OD',
         collateralAmount: formatWithCommas(collateral) + ' ' + collateralName,
         collateralizationRatio: Number(singleSafe?.collateralRatio),
@@ -90,13 +90,13 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
         <>
             <Flex>
                 <Left>
-                    <Inner className="main">
+                    <InnerLeft className="main">
                         <Main>
-                                <div>
-                                    <div style={{width: '100%', height: '100%', position: 'relative'}} dangerouslySetInnerHTML={{__html: svg}}></div>
+                                <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%', position: 'relative', overflow: 'scroll'}}>
+                                    <div style={{maxWidth: '100%', height: 'auto', border: '1px solid #00374E', borderRadius: '0px'}} dangerouslySetInnerHTML={{__html: svg}}></div>
                                 </div>
                         </Main>
-                    </Inner>
+                    </InnerLeft>
                 </Left>
 
                 <Right>
@@ -276,10 +276,11 @@ const Flex = styled.div`
     }
 `
 
-const ColumnWrapper = styled.div`
+const InnerLeft = styled.div`
+    height: 100%;
     display: flex;
-    justify-content: space-between;
-    gap: 24px;
+    flex-direction: column;
+    justify-content: center;
 `
 
 const Inner = styled.div`
@@ -334,6 +335,9 @@ const Side = styled.div`
     }
   border-bottom: 1px solid #00587E;
   padding-bottom: 8px;
+  svg {
+    border: 1px solid #00374E;
+  }
 `
 
 const SideTitle = styled.div`

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -91,44 +91,6 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                 <Left>
                     <Inner className="main">
                         <Main>
-                            <MainLabel>{singleSafe?.collateralName} Collateral</MainLabel>
-                            <RowWrapper>
-                                <div>
-                                    <MainValue>{formatWithCommas(collateral)}</MainValue>
-                                    <MainChange>${formatWithCommas(collateralInUSD, 2, 2)}</MainChange>
-                                </div>
-                                {modified ? (
-                                    <AfterTextWrapper>
-                                        After:{' '}
-                                        <span className={isDeposit ? 'green' : 'yellow'}>
-                                            {formatWithCommas(newCollateral)}
-                                        </span>
-                                    </AfterTextWrapper>
-                                ) : (
-                                    <></>
-                                )}
-                            </RowWrapper>
-                        </Main>
-
-                        <Main className="mid">
-                            <MainLabel>OD Debt</MainLabel>
-                            <RowWrapper>
-                                <div>
-                                    <MainValue>{formatWithCommas(totalDebt)}</MainValue>
-                                    <MainChange>${formatWithCommas(totalDebtInUSD, 2, 2)}</MainChange>
-                                </div>
-                                {modified ? (
-                                    <AfterTextWrapper>
-                                        After:{' '}
-                                        <span className={isDeposit ? 'green' : 'yellow'}>
-                                            {formatWithCommas(newDebt, 2)}
-                                        </span>
-                                    </AfterTextWrapper>
-                                ) : null}
-                            </RowWrapper>
-                        </Main>
-
-                        <Main>
                             <ColumnWrapper>
                                 <Column>
                                     <MainLabel>Collateral Ratio (min {collateralRatio}%)</MainLabel>
@@ -196,6 +158,43 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
 
                 <Right>
                     <Inner>
+                        <Side>
+                            <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('debt_owed_tip')}>
+                                <Info size="16" />
+                            </InfoIcon>
+                            <SideTitle>
+                                Debt Owed
+                                {modified ? (
+                                    <div className="sideNote">
+                                        After:{' '}
+                                        <span className={isDeposit ? 'green' : 'yellow'}>
+                                            {formatWithCommas(newDebt, 2)}
+                                        </span>
+                                    </div>
+                                ) : null}
+                            </SideTitle>
+                            <SideValue>{formatWithCommas(totalDebt)} OD</SideValue>
+                        </Side>
+                        <Side>
+                            <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('collateral_deposited_tip')}>
+                                <Info size="16" />
+                            </InfoIcon>
+                            <SideTitle>
+                                Collateral Deposited
+                                <MainChange>${formatWithCommas(collateralInUSD, 2, 2)}</MainChange>
+                                {modified ? (
+                                        <div className="sideNote">
+                                        After:{' '}
+                                        <span className={isDeposit ? 'green' : 'yellow'}>
+                                            {formatWithCommas(newCollateral)}
+                                        </span>
+                                        </div>
+                                ) : (
+                                    <></>
+                                )}
+                            </SideTitle>
+                            <SideValue>{formatWithCommas(collateral)} {singleSafe?.collateralName}</SideValue>
+                        </Side>
                         <Side>
                             <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('eth_osm_tip')}>
                                 <Info size="16" />

--- a/src/containers/Vaults/VaultHeader.tsx
+++ b/src/containers/Vaults/VaultHeader.tsx
@@ -35,7 +35,7 @@ const VaultHeader = ({
                 <LeftSide>
                     <SafeInfo>
                         <UpperInfo>
-                            Vault <span>#{safeId}</span>
+                            {singleSafe?.collateralName} Vault <span>#{safeId}</span>
                         </UpperInfo>
                     </SafeInfo>
                 </LeftSide>

--- a/src/utils/i18n/en.json
+++ b/src/utils/i18n/en.json
@@ -120,6 +120,8 @@
     "liquidate_button": "Liquidate Vault #",
     "eth_next_osm_tip": "Next collateral price that will be used by the system. This price is updated once per hour",
     "eth_osm_tip": "Current collateral price used by the system. This price is delayed 1h from the live collateral price feed and it’s only updated once per hour",
+    "debt_owed_tip": "Total amount of OD that is owed by this vault",
+    "collateral_deposited_tip": "Total amount of collateral that is deposited in this vault",
     "stability_fee_tip": " It is the annual interest rate paid by Vault owners on their debt. Proceeds from the borrow rate go to the protocol’s balance sheet",
     "hai_red_price_tip": "OD’s “moving peg”. It’s the price at which OD is minted or repaid inside the protocol. The OD market price is expected to fluctuate around the redemption price",
     "moneygod_desc": "The Money God League is an initiative to help other teams launch their own OD like assets and share a stake in each of their protocols with the Open Dollar community. You can stake ODG or ODG/ETH Uniswap v2 LP tokens and receive (un)governance tokens in League participants.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,7 +2268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/contracts@npm:5.7.0":
+"@ethersproject/contracts@npm:5.7.0, @ethersproject/contracts@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/contracts@npm:5.7.0"
   dependencies:
@@ -2529,7 +2529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@npm:5.7.2, @ethersproject/providers@npm:^5":
+"@ethersproject/providers@npm:5.7.2, @ethersproject/providers@npm:^5, @ethersproject/providers@npm:^5.7.2":
   version: 5.7.2
   resolution: "@ethersproject/providers@npm:5.7.2"
   dependencies:
@@ -3590,6 +3590,16 @@ __metadata:
   peerDependencies:
     utf-8-validate: ^5.0.2
   checksum: c63981be86dca38755fcf5cfd49518f4e2478693221052c2633e1608f2417986f74195bcdb90c8481680c31da521d9c10f7da3bb938923075942e98aefa70787
+  languageName: node
+  linkType: hard
+
+"@opendollar/svg-generator@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@opendollar/svg-generator@npm:1.0.0"
+  dependencies:
+    "@ethersproject/contracts": ^5.7.0
+    "@ethersproject/providers": ^5.7.2
+  checksum: c97097b34cfb6c67e836172dbe085263b2943f545bb61b52042f88e2e269873d1d48249be549d986732650846147b45fb03004f2a03dcdcbb532fc9727082095
   languageName: node
   linkType: hard
 
@@ -5183,6 +5193,7 @@ __metadata:
     "@ethersproject/providers": 5.4.5
     "@gnosis.pm/safe-apps-web3-react": ^0.6.0
     "@opendollar/sdk": ^1.5.6-rc.2
+    "@opendollar/svg-generator": 1.0.0
     "@react-spring/web": ^9.7.3
     "@testing-library/jest-dom": ^4.2.4
     "@testing-library/react": ^9.3.2


### PR DESCRIPTION
Closes #168 

**Can't be merged until opendollar/svg-playground 1.0.0 is published**


## Description
- New vaults page that corresponds to app design
- Vaults page uses new renderSvg function coming from svg-playground package (separate PR)

## Screenshots

Desktop

<img width="1343" alt="desktop" src="https://github.com/open-dollar/od-app/assets/47253537/913dc920-7fc4-4c1f-982d-7b10033730d1">

Mobile

<img width="442" alt="mobile" src="https://github.com/open-dollar/od-app/assets/47253537/6d9122eb-1a86-428c-9083-0476bc63d023">

Responsive

https://github.com/open-dollar/od-app/assets/47253537/aa3971cd-525a-498b-afc4-96e3d7c43ad0

Depositing collateral

<img width="1438" alt="deposit collateral" src="https://github.com/open-dollar/od-app/assets/47253537/6ad9bc19-0a5f-4ed1-a63d-2318f4082757">

Borrowing OD

<img width="1387" alt="borrow OD" src="https://github.com/open-dollar/od-app/assets/47253537/ed43c3e8-c1f3-41e9-b169-344f63523007">

Another vault example

<img width="1076" alt="another example" src="https://github.com/open-dollar/od-app/assets/47253537/f77d8a58-1cfe-4ce4-9a56-cb3072d11694">

