### PR TITLE
Issue #182: Re-order auctions

### DIFF
--- a/src/containers/Auctions/index.tsx
+++ b/src/containers/Auctions/index.tsx
@@ -25,7 +25,7 @@ const Auctions = ({
     const [showFaqs, setShowFaqs] = useState(false)
     const query = useQuery()
     const queryType = query.get('type') as AuctionEventType | null
-    const [type, setType] = useState<AuctionEventType>(queryType || 'SURPLUS')
+    const [type, setType] = useState<AuctionEventType>(queryType || 'COLLATERAL')
     const [error, setError] = useState('')
     const [isLoading, setIsLoading] = useState(false)
     const [selectedItem, setSelectedItem] = useState<string>('WSTETH')
@@ -108,7 +108,7 @@ const Auctions = ({
         if (queryType) {
             setType(queryType)
         } else {
-            setType('SURPLUS')
+            setType('COLLATERAL')
         }
     }, [queryType])
 
@@ -164,14 +164,14 @@ const Auctions = ({
             </Content>
 
             <Switcher>
-                <Tab className={type === 'DEBT' ? 'active' : ''} onClick={() => onTabClick('DEBT')}>
-                    Debt Auctions
+                <Tab className={type === 'COLLATERAL' ? 'active' : ''} onClick={() => onTabClick('COLLATERAL')}>
+                    Collateral Auctions
                 </Tab>
                 <Tab className={type === 'SURPLUS' ? 'active' : ''} onClick={() => onTabClick('SURPLUS')}>
                     Surplus Auctions
                 </Tab>
-                <Tab className={type === 'COLLATERAL' ? 'active' : ''} onClick={() => onTabClick('COLLATERAL')}>
-                    Collateral Auctions
+                <Tab className={type === 'DEBT' ? 'active' : ''} onClick={() => onTabClick('DEBT')}>
+                    Debt Auctions
                 </Tab>
             </Switcher>
 


### PR DESCRIPTION
Closes #182 

## Description
- Reordered auctions to be collateral, surplus, debt
- Collateral now is open by default

## Screenshots

New order

<img width="1418" alt="Screenshot 2023-11-02 at 1 51 16 PM" src="https://github.com/open-dollar/od-app/assets/47253537/3a2569d2-757b-4b6a-9153-be93f0f79605">


Demo

https://github.com/open-dollar/od-app/assets/47253537/21d69be1-ff46-47f0-8831-1fc94c4fbba5

