### PR TITLE
Issue #180: FE QA 10-30

### DIFF
--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -250,10 +250,10 @@ const CreateVault = ({
                                                   }
                                                 : undefined
                                         }
-                                        label={`Balance: ${formatWithCommas(selectedTokenBalance)} ${
+                                        label={`Balance: ${formatWithCommas(selectedTokenBalance, 2)} ${
                                             selectedCollateral?.symbol
                                         }`}
-                                        rightLabel={`~$${formatWithCommas(selectedTokenBalanceInUSD)}`}
+                                        rightLabel={`~$${formatWithCommas(selectedTokenBalanceInUSD, 2)}`}
                                         onChange={onLeftInput}
                                         value={leftInput}
                                         handleMaxClick={onMaxLeftInput}

--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -271,13 +271,13 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
                                 }
                                 label={
                                     isDeposit
-                                        ? `Borrow OD: ${formatWithCommas(availableHai)} ${tokensData.OD.symbol}`
-                                        : `Balance: ${formatWithCommas(haiBalance)} ${tokensData.OD.symbol}`
+                                        ? `Borrow OD: ${formatWithCommas(availableHai, 2)} ${tokensData.OD.symbol}`
+                                        : `Balance: ${formatWithCommas(haiBalance, 2)} ${tokensData.OD.symbol}`
                                 }
                                 rightLabel={
                                     isDeposit
-                                        ? `~$${formatWithCommas(haiBalanceUSD)}`
-                                        : `OD Owed: ${formatWithCommas(availableHai)}`
+                                        ? `~$${formatWithCommas(haiBalanceUSD, 2)}`
+                                        : `OD Owed: ${formatWithCommas(availableHai, 2)}`
                                 }
                                 onChange={onRightInput}
                                 value={rightInput}

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -253,8 +253,8 @@ export const ratioChecker = (currentLiquidationRatio: number, liqRatio: number, 
     const currentLiquidationRatioAsDecimal = currentLiquidationRatio / 100
 
     if (currentLiquidationRatioAsDecimal === 0) return 0
-    if (currentLiquidationRatioAsDecimal < liqRatio) return 4
     if (currentLiquidationRatioAsDecimal === liqRatio) return 3
+    if (currentLiquidationRatioAsDecimal < liqRatio) return 4
     if (currentLiquidationRatioAsDecimal > liqRatio && currentLiquidationRatioAsDecimal <= safetyRatio) return 3
     if (currentLiquidationRatioAsDecimal > safetyRatio && currentLiquidationRatioAsDecimal <= safetyRatio * 1.2)
         return 2

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -254,6 +254,7 @@ export const ratioChecker = (currentLiquidationRatio: number, liqRatio: number, 
 
     if (currentLiquidationRatioAsDecimal === 0) return 0
     if (currentLiquidationRatioAsDecimal < liqRatio) return 4
+    if (currentLiquidationRatioAsDecimal === liqRatio) return 3
     if (currentLiquidationRatioAsDecimal > liqRatio && currentLiquidationRatioAsDecimal <= safetyRatio) return 3
     if (currentLiquidationRatioAsDecimal > safetyRatio && currentLiquidationRatioAsDecimal <= safetyRatio * 1.2)
         return 2

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -253,7 +253,7 @@ export const ratioChecker = (currentLiquidationRatio: number, liqRatio: number, 
     const currentLiquidationRatioAsDecimal = currentLiquidationRatio / 100
 
     if (currentLiquidationRatioAsDecimal === 0) return 0
-    if (currentLiquidationRatioAsDecimal <= liqRatio) return 4
+    if (currentLiquidationRatioAsDecimal < liqRatio) return 4
     if (currentLiquidationRatioAsDecimal > liqRatio && currentLiquidationRatioAsDecimal <= safetyRatio) return 3
     if (currentLiquidationRatioAsDecimal > safetyRatio && currentLiquidationRatioAsDecimal <= safetyRatio * 1.2)
         return 2

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -136,13 +136,13 @@ describe('utils', () => {
         })
 
         it('returns 3 when currentLiquidationRatio is less than or equal to safetyRatio but greater than liqRatio', () => {
-            expect(ratioChecker(100, 1.0, 1.0)).toEqual(4)
+            expect(ratioChecker(100, 1.0, 1.0)).toEqual(3)
             expect(ratioChecker(150, 1.2, 1.5)).toEqual(3)
         })
 
-        it('returns 4 when currentLiquidationRatio is less than or equal to liqRatio', () => {
-            expect(ratioChecker(100, 1.0, 1.0)).toEqual(4)
-            expect(ratioChecker(135, 1.35, 1.35)).toEqual(4)
+        it('returns 4 when currentLiquidationRatio is less than liqRatio and 3 when equal', () => {
+            expect(ratioChecker(100, 1.0, 1.0)).toEqual(3)
+            expect(ratioChecker(135, 1.35, 1.35)).toEqual(3)
         })
     })
 


### PR DESCRIPTION
Closes #180 

## Description
- Limited balance amounts on vaults when creating/modifying them to two decimal places
- Changed liquidation logic from currentLiquidationRatioAsDecimal <= liqRatio to currentLiquidationRatioAsDecimal < liqRatio and if they're equal then return 3 (elevated)
- Replaced collateral ratio in global stats with total collateral locked (global collateral ratio was not being used before)

## Screenshots

Before limiting decimal points on balance and OD owed amounts

<img width="1165" alt="before" src="https://github.com/open-dollar/od-app/assets/47253537/5654e6f9-9a9e-4aef-a9de-529f6e49d76e">

After limiting decimal points on balance and OD owed amounts

<img width="1244" alt="after" src="https://github.com/open-dollar/od-app/assets/47253537/928651f5-9a76-4288-954e-a0460f43876b">

Repay not throwing errors (note that svg rendering logic will have to be changed in the svg generator package so that it will show elevated rather than liquidation after repaying)

https://github.com/open-dollar/od-app/assets/47253537/549f758a-15cb-428b-889d-dbe5b7518019

Global stats before

<img width="1020" alt="global stats before" src="https://github.com/open-dollar/od-app/assets/47253537/c11d8e96-b809-42ea-b92d-f7801565aac5">

Global stats after

<img width="1072" alt="global stats after" src="https://github.com/open-dollar/od-app/assets/47253537/7f36fe1f-2c53-4707-a81d-ec0f6ff3a7be">




