### PR TITLE
Issue #139: QA: Collateral Auction empty error

### DIFF
--- a/src/containers/Auctions/CollateralAuctions/CollateralAuctionBlock.tsx
+++ b/src/containers/Auctions/CollateralAuctions/CollateralAuctionBlock.tsx
@@ -125,7 +125,7 @@ const CollateralAuctionBlock = (auction: Props) => {
     const collateralPrice = useMemo(() => {
         if (auctionsState.collateralData) {
             const data = auctionsState.collateralData.filter((item) => item._auctionId.toString() === auctionId)
-            const price = data[0]?._boughtCollateral.mul(constants.WeiPerEther).div(data[0]._adjustedBid)
+            const price = data[0]?._boughtCollateral.mul(constants.WeiPerEther).div(data[0]._adjustedBid.gt(0) ? data[0]._adjustedBid : 1)
 
             // we divide by 1e18 because we multiplied by 1e18 in the line above
             // this was required to handle decimal prices (<0)
@@ -160,9 +160,9 @@ const CollateralAuctionBlock = (auction: Props) => {
 
     const auctionDateString = calculateAuctionEnd()
 
-    let auctionPrice = BigNumber.from(odBalance)
+    let auctionPrice = maxCollateral && maxCollateral.gt(BigNumber.from('0')) ? BigNumber.from(odBalance)
         .mul(BigNumber.from(marketPriceOD))
-        .div(maxCollateral && maxCollateral.gt(BigNumber.from('0')) ? maxCollateral : BigNumber.from('1'))
+        .div(maxCollateral) : BigNumber.from('0')
 
     const collateralLiquidationData = liquidationData ? liquidationData!.collateralLiquidationData[tokenSymbol] : null
 


### PR DESCRIPTION
Closes #139 

## Description
After fixing the SDK parseEvents issue the division by zero error happens after an auction has been settled. I fixed this by adding validation to ensure price calculation never involves division by 0. 

I also changed the auctionPrice calculation to be 0 when maxCollateral = 0. (Otherwise it ends up returning a huge number because marketPriceOD is multiplied by odBalance and it throws off the discount % as well)

## Screenshots

Before fix

<img width="1074" alt="Screenshot 2023-11-16 at 2 02 18 PM" src="https://github.com/open-dollar/od-app/assets/47253537/281010de-1d37-417f-908a-2097136a6c05">

After fix

https://github.com/open-dollar/od-app/assets/47253537/877f6697-69b3-4da1-b8bd-975edc61a433

After fix 2

https://github.com/open-dollar/od-app/assets/47253537/199c67c7-2cab-48cf-a8d9-d33df1520bae






