### PR TITLE
Issue #196: Repay & Withdraw Rounding Issue 

### DIFF
--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -283,6 +283,7 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
                                 value={rightInput}
                                 handleMaxClick={onMaxRightInput}
                                 disabled={isDeposit && !isOwner}
+                                decimals={5}
                             />
                         </InputBlock>
                     </Inner>


### PR DESCRIPTION
Closes #196 

## Description
- The default # of decimals for the TokenInput component is 4 but this is not precise enough to satisfy our validation that ensures we don't leave residual OD when repaying OD so I changed to 5 for this particular use of TokenInput

## Screenshots

Before

<img width="1063" alt="before" src="https://github.com/open-dollar/od-app/assets/47253537/fc2f01b1-bcc5-41c3-a757-6b6aa39c4a2c">

After example 1

https://github.com/open-dollar/od-app/assets/47253537/36cc255e-315c-4fb0-b71a-ed60b35ea1a7


After example 2

<img width="1034" alt="Screenshot 2023-11-28 at 1 25 40 PM" src="https://github.com/open-dollar/od-app/assets/47253537/af6fa621-0203-4dc1-944b-ec5c3349646e">


Repay successful

https://github.com/open-dollar/od-app/assets/47253537/40bbefce-8349-471e-a0bd-3727578b68fb



