### PR TITLE
Relates to Issue #205: Bug: collateral ratio NaN

### DIFF
--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -58,7 +58,7 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
             ).toString() + '%',
         debtAmount: formatWithCommas(totalDebt) + ' OD',
         collateralAmount: formatWithCommas(collateral) + ' ' + collateralName,
-        collateralizationRatio: Number(singleSafe?.collateralRatio),
+        collateralizationRatio: singleSafe?.collateralRatio === '∞' ? '∞' : Number(singleSafe?.collateralRatio),
         safetyRatio: Number(safeState.liquidationData!.collateralLiquidationData[collateralName].safetyCRatio),
         liqRatio: Number(safeState.liquidationData!.collateralLiquidationData[collateralName].liquidationCRatio),
     }


### PR DESCRIPTION
relates to https://github.com/open-dollar/od-app/issues/205

this is the od-app PR, but the svg-generator PR is here: https://github.com/open-dollar/svg-generator/pull/13

## Description
- We need to pass the infinity symbol to the svg-generator so that we're not passing NaN when the collateral ratio is infinity

## Screenshots

Successfully working with new svg-generator code 

<img width="1008" alt="Screenshot 2023-12-28 at 2 15 03 PM" src="https://github.com/open-dollar/od-app/assets/47253537/73ad4690-98ec-4e2f-be6f-d386d9279f5b">
