### PR TITLE
 Issue #208: Price showing total, not deposit amount

### DIFF
--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -58,10 +58,7 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
     const collateralUnitPriceUSD = formatNumber(
         safeState.liquidationData!.collateralLiquidationData[singleSafe!.collateralName].currentPrice.value
     )
-    const selectedTokenBalanceInUSD = formatNumber(
-        (Number(collateralUnitPriceUSD) * Number(leftInputBalance)).toString(),
-        2
-    )
+
     const selectedTokenDecimals = singleSafe ? tokenBalances[singleSafe.collateralName].decimals : '18'
 
     const [unlockState, approveUnlock] = useTokenApproval(
@@ -93,6 +90,12 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
     const haiBalance = ethers.utils.formatEther(tokenBalances.OD?.balanceE18 || '0')
 
     const haiBalanceUSD = useTokenBalanceInUSD('OD', rightInput ? rightInput : availableHai)
+
+    const collateralBalanceUSD = useTokenBalanceInUSD(
+        // @ts-ignore
+        singleSafe?.collateralName,
+        leftInput ? leftInput : 0
+    )
 
     const onMaxLeftInput = () => {
         if (isDeposit) {
@@ -250,7 +253,7 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
                                               singleSafe.collateralName
                                           }`
                                 }
-                                rightLabel={`~$${formatWithCommas(selectedTokenBalanceInUSD)}`}
+                                rightLabel={`~$${formatWithCommas(collateralBalanceUSD)}`}
                                 onChange={onLeftInput}
                                 value={leftInput}
                                 handleMaxClick={onMaxLeftInput}


### PR DESCRIPTION
Closes #208 

## Description
- Now the USD price of the collateral is based off the user's *input* rather than the user's wallet balance. Note that this new behavior is for both deposit and borrow and repay and withdraw, do we want to limit it? (see demo below)
- I added the ts-ignore because singleSafe?.collateralName is type string and useTokenBalanceInUSD() expects a type TokenType, which will always be provided by singleSafe?.collateralName anyway

## Screenshots

Demo

https://github.com/open-dollar/od-app/assets/47253537/0ff932c3-fe6e-4255-bbb3-11f1079c7f11

