### PR TITLE
update text

### DIFF
--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -301,7 +301,7 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
                             unlockState === ApprovalState.PENDING || unlockState === ApprovalState.NOT_APPROVED ? (
                                 <Button
                                     disabled={!isValid || unlockState === ApprovalState.PENDING}
-                                    text={unlockState === ApprovalState.PENDING ? 'Pending Approval..' : 'Unlock OD'}
+                                    text={unlockState === ApprovalState.PENDING ? 'Pending Approval..' : 'Approve OD'}
                                     onClick={approveUnlock}
                                 />
                             ) : (


### PR DESCRIPTION
elsewhere in the app token approvals are called Approve. Example, when depositing tokens or making new vaults
<img width="901" alt="Screen Shot 2024-01-24 at 9 24 12 AM" src="https://github.com/open-dollar/od-app/assets/9449596/712a10d2-b699-44cb-860a-644fe9ea1cfe">


It should be consistent everywhere saying approve, not "unlock". This is a token approval.

