### PR TITLE
Issue #255: Modify collateral validation

### DIFF
--- a/src/hooks/useSafe.ts
+++ b/src/hooks/useSafe.ts
@@ -258,7 +258,12 @@ export function useSafeInfo(type: SafeTypes = 'create') {
         if (rightInputBN.gt(availableHaiBN)) {
             error = error ?? `OD to repay cannot exceed owed amount`
         }
-
+        if (rightInputBN.eq(availableHaiBN) || (rightInputBN.lt(availableHaiBN) && rightInputBN.gt(availableHaiBN.sub(ONE_DAY_WORTH_SF))) && leftInputBN.lt(availableCollateralBN)) {
+            error = error ?? `You must withdraw all ${collateralName} when repaying all OD`;
+        }
+        if (!rightInputBN.isZero() && leftInputBN.lt(ethers.utils.parseEther('0.01'))) {
+            error = error ?? `You must withdraw more than 0.01 ${collateralName} when repaying`;
+        }
         if (!rightInputBN.isZero()) {
             const repayPercent = returnPercentAmount(rightInput, availableHai as string)
 


### PR DESCRIPTION
Closes #255 

## Description
Adds two new client-side validation cases when doing repay/withdraw
1) First we check to see if the user is repaying all (or nearly all) the OD. If so, we make them withdraw all the collateral because otherwise the transaction will fail (see video below). I say *nearly all* because there's a buffer zone where the amount the user inputs may not be perfectly equal to the available debt to withdraw, but also not so little that it leaves residual values. So we need a small buffer to avoid issues where the repay amount is off by let's say .0000011 when in reality the user is repaying all (and the transaction will go through with all)
2) If the user is repaying just some OD we want to enforce an amount of collateral that they have to withdraw. In your original issue you said "that at least 1 OD is withdrawn" but I think you meant 1 of whatever collateral it is. I found that 1 is a little much (especially for more expensive collateral like WSTETH) and I found that 0.01 is a good value for now to enforce. Do you want me to change it to 1?

## Screenshots

Before my changes: withdrawing SOME collateral is not sufficient if we're repaying ALL OD. As you can see here the transaction fails

https://github.com/open-dollar/od-app/assets/47253537/4d10ef60-eaf4-46e4-90b1-6e8b43365005

After my changes: we now validate that the user withdraws ALL collateral when repaying ALL OD


https://github.com/open-dollar/od-app/assets/47253537/3eecb252-744e-4d8d-98b8-6a0ec3134015


After my changes: we now validate that the user must withdraw at least 0.01 of the collateral when repaying SOME OD

https://github.com/open-dollar/od-app/assets/47253537/2a04bed7-9aa6-4355-acc5-1ae1897cb7d2





