### PR TITLE
Issue #247: Restrict Leading Zeros in TokenInput

### DIFF
--- a/src/components/TokenInput.tsx
+++ b/src/components/TokenInput.tsx
@@ -42,8 +42,8 @@ const TokenInput = ({
     const handleValueChange = (values: NumberFormatValues) => {
         const { value } = values
 
-        if (value === ".") {
-            onChange("0.")
+        if (value === '.') {
+            onChange('0.')
             return
         }
 

--- a/src/components/TokenInput.tsx
+++ b/src/components/TokenInput.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Loader } from 'react-feather'
 import styled from 'styled-components'
-import { NumericFormat } from 'react-number-format'
+import { NumericFormat, NumberFormatValues } from 'react-number-format'
 
 interface Props {
     label: string
@@ -39,9 +39,30 @@ const TokenInput = ({
 
     const [length] = useState(16)
 
-    const handleValueChange = (values: any) => {
+    const handleValueChange = (values: NumberFormatValues) => {
         const { value } = values
+
+        if (value === ".") {
+            onChange("0.")
+            return
+        }
+
         onChange(value)
+    }
+
+    const validateInput = (values: NumberFormatValues) => {
+        const { formattedValue, value } = values
+        const [firstChar, secondChar] = [value.charAt(0), value.charAt(1)]
+
+        if (firstChar === '.') {
+            return true
+        }
+
+        if (firstChar === '0' && secondChar && secondChar !== '.') {
+            return false
+        }
+
+        return formattedValue === '' || Number(formattedValue) >= 0
     }
 
     return (
@@ -70,6 +91,7 @@ const TokenInput = ({
                         disabled={disabled}
                         customInput={CustomInput} // You use your styled component as the actual input
                         data-test-id={data_test_id}
+                        isAllowed={validateInput}
                     />
                 </Flex>
                 <Flex>

--- a/src/containers/Vaults/Stats.js
+++ b/src/containers/Vaults/Stats.js
@@ -54,7 +54,8 @@ const Stats = () => {
                     <a
                         style={{ color: '#1499DA', fontWeight: '600', fontSize: '14px' }}
                         href="https://stats.opendollar.com/"
-                        target="_blank" rel="noreferrer"
+                        target="_blank"
+                        rel="noreferrer"
                     >
                         View All Stats
                     </a>


### PR DESCRIPTION
Closes #247 

### Description
- Restricts leading zero input
- Allows initial character to be decimal point, but formats it as "0."

### Screenshots
(Spamming zero in video but it isn't showing up)

https://github.com/open-dollar/od-app/assets/90171376/0d735cb6-a2a1-41e1-94f5-bc6b2c9862c7

