### PR TITLE
Issue #261: Disable withdrawing all collateral from vault

### DIFF
--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -234,6 +234,8 @@ export const getLiquidationPrice = (
 export const safeIsSafe = (totalCollateral: string, totalDebt: string, safetyPrice: string): Boolean => {
     if (isNaN(Number(totalDebt))) return true
     const totalDebtBN = BigNumber.from(toFixedString(totalDebt, 'WAD'))
+    // We cannot withdraw more than the total collateral
+    if (Number(totalCollateral) < 0) return false
     const totalCollateralBN = BigNumber.from(toFixedString(totalCollateral, 'WAD'))
     const safetyPriceBN = BigNumber.from(toFixedString(safetyPrice, 'RAY'))
     return totalDebtBN.lte(totalCollateralBN.mul(safetyPriceBN).div(gebUtils.RAY))


### PR DESCRIPTION
Closes #261 

## Description
- Because of the precision of values in the app totalCollateral can be less than zero if the user presses "max" (it's negative by something .000001). This validation ensures a vault action won't be considered safe in this case, and disables the user from trying to submit the transaction

## Screenshots

Before, withdraw all collateral is incorrectly enabled

<img width="1185" alt="before" src="https://github.com/open-dollar/od-app/assets/47253537/d6f6f457-23e4-4cd2-8f16-4e3d1f2decb0">

After, withdraw all collateral is correctly disabled

<img width="981" alt="after" src="https://github.com/open-dollar/od-app/assets/47253537/26c8619f-b786-4c06-9a9d-1903587bbcad">


