### PR TITLE
Issue #266: Node vercel compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
         "format": "yarn run prettier:fix && yarn run lint:fix",
         "format:check": "yarn run prettier && yarn run lint"
     },
+    "engines": {
+        "node": ">=20.0.0"
+    },
     "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"


### PR DESCRIPTION
Closes #266 

## Description
- Updates node version--Vercel naturally picks up on the engine version but if it doesn't work I can change it manually in Vercel settings

I always use node 20 when using the app so I don't think the upgrade should be an issue