### PR TITLE
Issue #269: Gnosis Safe Chain ID Issues 

### DIFF
--- a/src/components/ConnectWithSelect.tsx
+++ b/src/components/ConnectWithSelect.tsx
@@ -86,7 +86,7 @@ export function ConnectWithSelect({
                             }
                         }}
                     >
-                        {connector instanceof MetaMask ? '' : <>{'Disconnect'}</>}
+                        {connector instanceof MetaMask || connector instanceof GnosisSafe ? '' : <>{'Disconnect'}</>}
                     </div>
                 )
             ) : (

--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -41,7 +41,7 @@ import {
     SYSTEM_STATUS,
     timeout,
     ChainId,
-    ETH_NETWORK,
+    ETH_NETWORK, IS_IN_IFRAME,
 } from '~/utils'
 import LiquidateSafeModal from '~/components/Modals/LiquidateSafeModal'
 import Footer from '~/components/Footer'
@@ -55,7 +55,7 @@ interface Props {
 
 const Shared = ({ children, ...rest }: Props) => {
     const { t } = useTranslation()
-    const { chainId, account, provider } = useActiveWeb3React()
+    const { chainId, account, provider, connector } = useActiveWeb3React()
     const geb = useGeb()
     const history = useHistory()
 
@@ -306,6 +306,21 @@ const Shared = ({ children, ...rest }: Props) => {
         accountChange()
         const id: ChainId = NETWORK_ID
         popupsActions.setIsSafeManagerOpen(false)
+        // Gnosis Safe is not compatible with Arbitrum testnets
+        if (connector && IS_IN_IFRAME && id !== 42161) {
+            connectWalletActions.setIsWrongNetwork(true)
+            toast(
+                <ToastPayload
+                    icon={'AlertTriangle'}
+                    iconSize={40}
+                    iconColor={'orange'}
+                    textColor={'#ffffff'}
+                    text={`${t('gnosis_safe_mainnet_only')}`}
+                />,
+                { autoClose: false, type: 'warning', toastId }
+            )
+            return
+        }
         if (chainId && chainId !== id) {
             const chainName = ETHERSCAN_PREFIXES[id]
             connectWalletActions.setIsWrongNetwork(true)

--- a/src/utils/i18n/en.json
+++ b/src/utils/i18n/en.json
@@ -23,6 +23,7 @@
     "confirm_details_text": "Please review and click on the Confirm Transaction button to submit and sign the transaction ",
     "view_etherscan": "View on Etherscan",
     "wrong_network": "Heads up, you’re on the wrong network! Please switch to ",
+    "gnosis_safe_mainnet_only": "Gnosis Safe isn't compatible with Arbitrum testnets. Please switch to a different wallet outside the Gnosis Safe App Viewer.",
     "account_details": "Account",
     "connected_with": "Connected with",
     "disconnect": "Disconnect",


### PR DESCRIPTION
Closes #269 

## Description
- Gnosis safe does not support the arbitrum testnets (https://help.safe.global/en/articles/40795-supported-networks) so this PR includes logic for disabling the app if the user is using an arbitrum testnet while using the gnosis safe app viewer (detected with the IS_IN_IFRAME function) 
- I get rid of the disconnect button if the user is using the gnosis safe app viewer because the app viewer keeps trying to inject the gnosis safe network context into the app (like MM) and given that all of our connectors try to connect eagerly (ensuring that the provider instance will persist upon refresh and navigation) it will cause issues if users try to use other wallets while in the gnosis safe app context

## Screenshots

App disabled & error message shown when user connects to testnet via gnosis safe context

https://github.com/open-dollar/od-app/assets/47253537/14983ef5-d2c3-4132-abff-bb408fadfb66

