### PR TITLE
Issue #247: Restrict Leading Zeros in TokenInput

### DIFF
--- a/src/components/TokenInput.tsx
+++ b/src/components/TokenInput.tsx
@@ -62,7 +62,7 @@ const TokenInput = ({
             return false
         }
 
-        return formattedValue === '' || Number(formattedValue) >= 0
+        return formattedValue === '' || Number(formattedValue.replace(/,/g, '')) >= 0
     }
 
     return (


### PR DESCRIPTION
Closes #247 
closes #271 

## Description
- The bug was caused by the Number(formattedValue) type coercion in this PR https://github.com/open-dollar/od-app/pull/260/files

When a number was let's say "3,300" then Number(formattedValue) would be false because the comma is not removed from the number before converting it

The fix is to use replace() to remove the comma from the number before the coercion

## Screenshots

Can now enter more than 3 numbers

https://github.com/open-dollar/od-app/assets/47253537/819c5d19-8e6b-441a-8d4c-eddccdd9b193

Previous bug fix still works (can't enter more than one consecutive zeros before the decimal)

https://github.com/open-dollar/od-app/assets/47253537/cac16f21-4d17-4b0a-9ad4-8c7a33db7804


