### PR TITLE
[Do not merge] Update sdk to 1.6.4-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@ethersproject/address": "^5.0.10",
         "@ethersproject/experimental": "5.4.0",
         "@ethersproject/providers": "5.4.5",
-        "@opendollar/sdk": "^1.6.1-rc.1",
+        "@opendollar/sdk": "^1.6.4-rc.1",
         "@opendollar/svg-generator": "1.0.3",
         "@react-spring/web": "^9.7.3",
         "@types/jest": "^24.0.0",
@@ -132,7 +132,8 @@
     "resolutions": {
         "@types/react": "17.0.2",
         "@types/react-dom": "17.0.2",
-        "react-error-overlay": "6.0.9"
+        "react-error-overlay": "6.0.9",
+        "@opendollar/sdk": "portal:/Users/dev/repos/opendollar/od-sdk"
     },
     "husky": {
         "hooks": {

--- a/package.json
+++ b/package.json
@@ -132,8 +132,7 @@
     "resolutions": {
         "@types/react": "17.0.2",
         "@types/react-dom": "17.0.2",
-        "react-error-overlay": "6.0.9",
-        "@opendollar/sdk": "portal:/Users/dev/repos/opendollar/od-sdk"
+        "react-error-overlay": "6.0.9"
     },
     "husky": {
         "hooks": {

--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -164,9 +164,9 @@ const Analytics = () => {
 
     const vaultNFTs = {
         image: 'NFTS',
-        title: 'Vault NFTs',
+        title: 'NFVs',
         value: totalVaults,
-        description: 'Vault NFTs',
+        description: 'NFVs',
     }
 
     const annualStabilityFee = {

--- a/src/utils/i18n/en.json
+++ b/src/utils/i18n/en.json
@@ -21,7 +21,7 @@
     "back": "Back",
     "confirm_transaction_details": "Confirm Transaction Details",
     "confirm_details_text": "Please review and click on the Confirm Transaction button to submit and sign the transaction ",
-    "view_etherscan": "View on Etherscan",
+    "view_etherscan": "View on Arbiscan",
     "wrong_network": "Heads up, you’re on the wrong network! Please switch to ",
     "account_details": "Account",
     "connected_with": "Connected with",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3636,16 +3636,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opendollar/sdk@portal:/Users/dev/repos/opendollar/od-sdk::locator=%40usekeyp%2Fod-app%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@opendollar/sdk@portal:/Users/dev/repos/opendollar/od-sdk::locator=%40usekeyp%2Fod-app%40workspace%3A."
+"@opendollar/sdk@npm:^1.6.4-rc.1":
+  version: 1.6.4-rc.1
+  resolution: "@opendollar/sdk@npm:1.6.4-rc.1"
   dependencies:
     "@opendollar/abis": "0.0.0-c0c20343 "
     ethers: 5.4.7
   peerDependencies:
     utf-8-validate: ^5.0.2
+  checksum: 6dd71a843fd6a7fa1690cac967ccdc54b0b3dcb744567e923a383fbcdf8111d61a8066caa92c48c339af6cd3acb2d719baae8233ff2f6445a9121d79fd181844
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@opendollar/svg-generator@npm:1.0.3":
   version: 1.0.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -3617,9 +3617,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opendollar/abis@npm:0.0.0-ddd353db":
-  version: 0.0.0-ddd353db
-  resolution: "@opendollar/abis@npm:0.0.0-ddd353db"
+"@opendollar/abis@npm:0.0.0-c0c20343 ":
+  version: 0.0.0-c0c20343
+  resolution: "@opendollar/abis@npm:0.0.0-c0c20343"
   dependencies:
     "@defi-wonderland/solidity-utils": 0.0.0-4298c6c6
     "@ethersproject/abi": 5.7.0
@@ -3632,21 +3632,20 @@ __metadata:
     ethers: 6.0.3
     forge-std: "git+https://github.com/foundry-rs/forge-std.git#e8a047e3f40f13fa37af6fe14e6e06283d9a060e"
     typechain: ^8.3.2
-  checksum: 37defa9fd986f0591610b2cf1cd8a4211b6d6c8e01ab1f1ad8a245f57fc84481553cb34e6dcc986d191fa53add65f772f07d9757239fb73bcf2f178a2ad56fb9
+  checksum: a1df9980c8c63b77b743c8992b0b5ac4faa49a9322f46f273c80ba3c00da42f53bd2931c974b00084fcc855cb77c81de5d5883f8d7210a2140eda8b1cc8e29b0
   languageName: node
   linkType: hard
 
-"@opendollar/sdk@npm:^1.6.1-rc.1":
-  version: 1.6.1-rc.1
-  resolution: "@opendollar/sdk@npm:1.6.1-rc.1"
+"@opendollar/sdk@portal:/Users/dev/repos/opendollar/od-sdk::locator=%40usekeyp%2Fod-app%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@opendollar/sdk@portal:/Users/dev/repos/opendollar/od-sdk::locator=%40usekeyp%2Fod-app%40workspace%3A."
   dependencies:
-    "@opendollar/abis": 0.0.0-ddd353db
+    "@opendollar/abis": "0.0.0-c0c20343 "
     ethers: 5.4.7
   peerDependencies:
     utf-8-validate: ^5.0.2
-  checksum: 524760d71abf0ada700ac825b53f9cb6148a1f7dcfcdedb5c23eed754afa0bc8b074b6f6d349b0d9fee77fd64f94d93acf0924868b1ef7fd1c06eadfd252fc31
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@opendollar/svg-generator@npm:1.0.3":
   version: 1.0.3
@@ -5370,7 +5369,7 @@ __metadata:
     "@ethersproject/address": ^5.0.10
     "@ethersproject/experimental": 5.4.0
     "@ethersproject/providers": 5.4.5
-    "@opendollar/sdk": ^1.6.1-rc.1
+    "@opendollar/sdk": ^1.6.4-rc.1
     "@opendollar/svg-generator": 1.0.3
     "@react-spring/web": ^9.7.3
     "@testing-library/jest-dom": ^6.4.2


### PR DESCRIPTION
Updates the sdk to v1.6.4-rc.1 which is only for the pentest deployment of the contracts.

If we decide to make this the new testnet version (eg. app.dev.opendollar.com) then we can merge