### PR TITLE
Issue #308: Debt owed, input owed amount

### DIFF
--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -37,7 +37,7 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
 
     const totalDebt = formatWithCommas(returnTotalDebt(singleSafe?.debt as string, collateralLiquidationData.accumulatedRate, true) as string, 3)
 
-    const totalDebtInUSD = useTokenBalanceInUSD('OD', returnTotalDebt(singleSafe?.debt as string, collateralLiquidationData.accumulatedRate, true) as string, 3)
+    const totalDebtInUSD = useTokenBalanceInUSD('OD', returnTotalDebt(singleSafe?.debt as string, collateralLiquidationData.accumulatedRate, true) as string, 2)
 
     const collateralName = singleSafe!.collateralName
     const collateralUnitPriceUSD = formatNumber(

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -35,9 +35,11 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
 
     const collateralLiquidationData = liquidationData!.collateralLiquidationData[singleSafe?.collateralName as string]
 
-    const totalDebt = formatWithCommas(returnTotalDebt(singleSafe?.debt as string, collateralLiquidationData.accumulatedRate, true) as string, 3)
+    const totalDebtCalc = returnTotalDebt(singleSafe?.debt as string, collateralLiquidationData.accumulatedRate, true) as string
 
-    const totalDebtInUSD = useTokenBalanceInUSD('OD', returnTotalDebt(singleSafe?.debt as string, collateralLiquidationData.accumulatedRate, true) as string, 2)
+    const totalDebt = formatWithCommas(totalDebtCalc, 3)
+
+    const totalDebtInUSD = useTokenBalanceInUSD('OD', totalDebtCalc, 2)
 
     const collateralName = singleSafe!.collateralName
     const collateralUnitPriceUSD = formatNumber(

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -5,7 +5,14 @@ import { Info } from 'react-feather'
 import Numeral from 'numeral'
 
 import { useTokenBalanceInUSD, useSafeInfo } from '~/hooks'
-import { formatNumber, formatWithCommas, getRatePercentage, ratioChecker, returnState } from '~/utils'
+import {
+    formatNumber,
+    formatWithCommas,
+    getRatePercentage,
+    ratioChecker,
+    returnState,
+    returnTotalDebt
+} from '~/utils'
 import { useStoreState } from '~/store'
 import { Tooltip as ReactTooltip } from 'react-tooltip'
 //@ts-ignore
@@ -22,13 +29,15 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
     } = useSafeInfo(isModifying ? (isDeposit ? 'deposit_borrow' : 'repay_withdraw') : 'info')
 
     const { safeModel: safeState } = useStoreState((state) => state)
-    const { singleSafe } = safeState
+    const { singleSafe, liquidationData } = safeState
 
     const collateral = formatNumber(singleSafe?.collateral || '0')
 
-    const totalDebt = formatNumber(singleSafe?.totalDebt || '0')
+    const collateralLiquidationData = liquidationData!.collateralLiquidationData[singleSafe?.collateralName as string]
 
-    const totalDebtInUSD = useTokenBalanceInUSD('OD', totalDebt as string)
+    const totalDebt = formatWithCommas(returnTotalDebt(singleSafe?.debt as string, collateralLiquidationData.accumulatedRate, true) as string, 3)
+
+    const totalDebtInUSD = useTokenBalanceInUSD('OD', returnTotalDebt(singleSafe?.debt as string, collateralLiquidationData.accumulatedRate, true) as string, 3)
 
     const collateralName = singleSafe!.collateralName
     const collateralUnitPriceUSD = formatNumber(

--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -107,7 +107,17 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
     }
 
     const onMaxRightInput = () => {
-        onRightInput(availableHai)
+        if (isDeposit) {
+            onRightInput(availableHai)
+        } else {
+            const availableHaiBN = ethers.utils.parseEther(availableHai)
+
+            const haiBalanceBN = tokenBalances.OD.balanceE18 ? tokenBalances.OD.balanceE18 : BigNumber.from('0')
+
+            const isMoreDebt = availableHaiBN.gt(haiBalanceBN)
+
+            onRightInput(isMoreDebt ? ethers.utils.formatEther(haiBalanceBN) : availableHai)
+        }
     }
 
     const handleWaitingTitle = () => {

--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -107,17 +107,7 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
     }
 
     const onMaxRightInput = () => {
-        if (isDeposit) {
-            onRightInput(availableHai)
-        } else {
-            const availableHaiBN = ethers.utils.parseEther(availableHai)
-
-            const haiBalanceBN = tokenBalances.OD.balanceE18 ? tokenBalances.OD.balanceE18 : BigNumber.from('0')
-
-            const isMoreDebt = availableHaiBN.gt(haiBalanceBN)
-
-            onRightInput(isMoreDebt ? ethers.utils.formatEther(haiBalanceBN) : availableHai)
-        }
+        onRightInput(availableHai)
     }
 
     const handleWaitingTitle = () => {

--- a/src/hooks/useGeb.ts
+++ b/src/hooks/useGeb.ts
@@ -3,7 +3,7 @@ import { Geb } from '@opendollar/sdk'
 
 import store, { useStoreActions, useStoreState } from '~/store'
 import { EMPTY_ADDRESS, network_name } from '~/utils/constants'
-import { formatNumber } from '~/utils/helper'
+import { formatNumber, formatWithCommas } from '~/utils/helper'
 import { useActiveWeb3React } from '~/hooks'
 import { NETWORK_ID } from '~/connectors'
 
@@ -85,13 +85,16 @@ export function useBlockNumber() {
 }
 
 // returns amount of currency in USD
-export function useTokenBalanceInUSD(token: TokenType, balance: string) {
+export function useTokenBalanceInUSD(token: TokenType, balance: string, minDecimals = 2) {
     const ethPrice = store.getState().connectWalletModel.fiatPrice
     const haiPrice = store.getState().safeModel.liquidationData?.currentRedemptionPrice
 
     return useMemo(() => {
         const price = token === 'ETH' || token === 'WETH' ? ethPrice : haiPrice
         if (!balance) return '0'
-        return formatNumber((Number(price) * Number(balance)).toString(), 2)
-    }, [token, ethPrice, haiPrice, balance])
+        if (minDecimals > 2) {
+            return formatWithCommas((Number(price) * Number(balance)).toString(), minDecimals)
+        }
+        return formatNumber((Number(price) * Number(balance)).toString(), minDecimals)
+    }, [token, ethPrice, haiPrice, balance, minDecimals])
 }

--- a/src/hooks/useGeb.ts
+++ b/src/hooks/useGeb.ts
@@ -92,9 +92,6 @@ export function useTokenBalanceInUSD(token: TokenType, balance: string, minDecim
     return useMemo(() => {
         const price = token === 'ETH' || token === 'WETH' ? ethPrice : haiPrice
         if (!balance) return '0'
-        if (minDecimals > 2) {
-            return formatWithCommas((Number(price) * Number(balance)).toString(), minDecimals)
-        }
         return formatNumber((Number(price) * Number(balance)).toString(), minDecimals)
     }, [token, ethPrice, haiPrice, balance, minDecimals])
 }


### PR DESCRIPTION
Closes #308 

- [X] Debt Owed: OD amount should show more decimals. The actual amount is 1,000.5043

I changed it to show 3 decimals now. Considering the real amount can be 18 digits I think 3 is a good amount, especially since now when we press "max" when repaying it'll fill in the debt owed with more than just 3 decimals anyway if needed (see video below)

- [X] Debt Owed: The USD amount should always show two decimals

- [ ] ~~Repay OD: There should be an option to repay the current debt owed. Currently you can only select the max OD in your wallet, but in this example I should be able to click a button that pre-fills my OD debt balance eg, 1,000.5043 OD~~

~~Before the app would max out at a user's wallet balance. I changed the "max" button logic to just fill in the max amount owed rather than the wallet balance amount~~

Reverted third change

## Screenshots

Example of 3 decimal debt owed value and 2 decimal debt owed in USD 

<img width="938" alt="2 decimals" src="https://github.com/open-dollar/od-app/assets/47253537/d6324781-9369-4f29-b952-fe9a4537c1ee">

Another example of 3 decimal debt owed value and 2 decimal debt owed in USD 

<img width="1000" alt="2 decimals another ex" src="https://github.com/open-dollar/od-app/assets/47253537/4f1af0bf-5bad-4f84-a77a-a396fa07804e">

When debt is 0 then decimal rules don't apply

<img width="1035" alt="not 2 decimals when 0" src="https://github.com/open-dollar/od-app/assets/47253537/3a2f58d2-1771-49f5-813c-2ef0762fecfb">


"Max" now fills in the whole amount owed when repaying

https://github.com/open-dollar/od-app/assets/47253537/ecb0785f-b4a3-4978-8da1-477e148ffc93

