### PR TITLE
Remove deprecated check

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,10 +18,6 @@ import type { WalletConnect as WalletConnectV2 } from '@web3-react/walletconnect
 import { GnosisSafe } from '@web3-react/gnosis-safe'
 import { gnosisSafe, hooks } from '~/connectors/gnosisSafe'
 
-if ('ethereum' in window) {
-    ;(window.ethereum as any).autoRefreshOnNetworkChange = false
-}
-
 const connectors: [MetaMask | WalletConnectV2 | CoinbaseWallet | Network | GnosisSafe, Web3ReactHooks][] = [
     [metaMask, metaMaskHooks],
     [walletConnectV2, walletConnectV2Hooks],


### PR DESCRIPTION
closes #327

#329 & #331 are separate issues

```TS
if ('ethereum' in window) {
    ;(window.ethereum as any).autoRefreshOnNetworkChange = false
}
```

Is deprecated, and no longer does anything + ```window.ethereum``` is will always result in a bug as you must check that both window, has loaded, then ethereum is loaded.

Since it doesn't do anything I just elected to remove it.