### PR TITLE
Global stability fee is incorrect

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -76,7 +76,7 @@ export const TESTNET_CHAINS: ChainConfig = {
         name: 'Arbitrum Sepolia',
         nativeCurrency: ETH,
         blockExplorerUrls: ['https://sepolia.arbiscan.io/'],
-    }
+    },
 }
 
 const supportedChainId = parseInt(process.env.REACT_APP_NETWORK_ID || '', 10)

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -144,7 +144,7 @@ export default function WalletModal() {
             setWalletView(WALLET_VIEWS.ACCOUNT)
         }
     }, [setWalletView, isActive, connector, isConnectorsWalletOpen, activePrevious, connectorPrevious])
-    
+
     function getHeaderContent() {
         if (process.env.REACT_APP_NETWORK_ID === '42161') {
             return (
@@ -164,7 +164,7 @@ export default function WalletModal() {
                     </a>
                 </h5>
             )
-        }  else if (process.env.REACT_APP_NETWORK_ID === '420') {
+        } else if (process.env.REACT_APP_NETWORK_ID === '420') {
             return (
                 <h5>
                     {t('not_supported')}{' '}
@@ -173,7 +173,6 @@ export default function WalletModal() {
                     </a>
                 </h5>
             )
-
         } else {
             return (
                 <h5>
@@ -193,9 +192,7 @@ export default function WalletModal() {
                 {String(chainId) !== process.env.REACT_APP_NETWORK_ID && chainId !== undefined ? (
                     <>
                         <HeaderRow>{'Wrong Network'}</HeaderRow>
-                        <ContentWrapper>
-                            {getHeaderContent()}
-                        </ContentWrapper>
+                        <ContentWrapper>{getHeaderContent()}</ContentWrapper>
                     </>
                 ) : (
                     <HeaderRow>

--- a/src/containers/Analytics/DataTable.tsx
+++ b/src/containers/Analytics/DataTable.tsx
@@ -37,16 +37,13 @@ export const DataTable = ({ title, colums, rows }: TableProps) => {
                                     if (valueIndex === 6) {
                                         return null
                                     }
-
                                     return (
-                                        <>
-                                            <HeadsContainer key={'row-item-' + valueIndex}>
-                                                <ListItem index={valueIndex}>
-                                                    <ListItemLabel>{colums[valueIndex]?.name}</ListItemLabel>
-                                                    {value}
-                                                </ListItem>
-                                            </HeadsContainer>
-                                        </>
+                                        <HeadsContainer key={'row-item-' + valueIndex}>
+                                            <ListItem index={valueIndex}>
+                                                <ListItemLabel>{colums[valueIndex]?.name}</ListItemLabel>
+                                                {value}
+                                            </ListItem>
+                                        </HeadsContainer>
                                     )
                                 })}
                             </List>

--- a/src/containers/Analytics/DataTable.tsx
+++ b/src/containers/Analytics/DataTable.tsx
@@ -40,7 +40,6 @@ export const DataTable = ({ title, colums, rows }: TableProps) => {
 
                                     return (
                                         <>
-                                            {console.log({ value }, valueIndex)}
                                             <HeadsContainer key={'row-item-' + valueIndex}>
                                                 <ListItem index={valueIndex}>
                                                     <ListItemLabel>{colums[valueIndex]?.name}</ListItemLabel>

--- a/src/containers/Analytics/DataTable.tsx
+++ b/src/containers/Analytics/DataTable.tsx
@@ -33,7 +33,7 @@ export const DataTable = ({ title, colums, rows }: TableProps) => {
                         {rows?.map((item, index) => (
                             <List key={'row-' + index}>
                                 {item?.map((value, valueIndex) => {
-                                    // Skip rendering the item if valueIndex is 6
+                                    // skip borrow rate info
                                     if (valueIndex === 6) {
                                         return null
                                     }

--- a/src/containers/Analytics/DataTable.tsx
+++ b/src/containers/Analytics/DataTable.tsx
@@ -35,8 +35,12 @@ export const DataTable = ({ title, colums, rows }: TableProps) => {
                                 {item?.map((value, valueIndex) => (
                                     <HeadsContainer key={'row-item-' + valueIndex}>
                                         <ListItem index={valueIndex}>
-                                            <ListItemLabel>{colums[valueIndex].name}</ListItemLabel>
-                                            {value}
+                                            {/* {console.log("column label: ", colums[valueIndex], "column value: ", value)} */}
+                                            {/* if I remove column, there is a wrong switch and all collumns are mixed */}
+                                            {colums[valueIndex] && (
+                                                <ListItemLabel>{colums[valueIndex].name}</ListItemLabel>
+                                            )}
+                                            {colums[valueIndex] && value}
                                         </ListItem>
                                     </HeadsContainer>
                                 ))}

--- a/src/containers/Analytics/DataTable.tsx
+++ b/src/containers/Analytics/DataTable.tsx
@@ -33,10 +33,6 @@ export const DataTable = ({ title, colums, rows }: TableProps) => {
                         {rows?.map((item, index) => (
                             <List key={'row-' + index}>
                                 {item?.map((value, valueIndex) => {
-                                    // skip borrow rate info
-                                    if (valueIndex === 6) {
-                                        return null
-                                    }
                                     return (
                                         <HeadsContainer key={'row-item-' + valueIndex}>
                                             <ListItem index={valueIndex}>

--- a/src/containers/Analytics/DataTable.tsx
+++ b/src/containers/Analytics/DataTable.tsx
@@ -32,18 +32,24 @@ export const DataTable = ({ title, colums, rows }: TableProps) => {
                     <ListContainer>
                         {rows?.map((item, index) => (
                             <List key={'row-' + index}>
-                                {item?.map((value, valueIndex) => (
-                                    <HeadsContainer key={'row-item-' + valueIndex}>
-                                        <ListItem index={valueIndex}>
-                                            {/* {console.log("column label: ", colums[valueIndex], "column value: ", value)} */}
-                                            {/* if I remove column, there is a wrong switch and all collumns are mixed */}
-                                            {colums[valueIndex] && (
-                                                <ListItemLabel>{colums[valueIndex].name}</ListItemLabel>
-                                            )}
-                                            {colums[valueIndex] && value}
-                                        </ListItem>
-                                    </HeadsContainer>
-                                ))}
+                                {item?.map((value, valueIndex) => {
+                                    // Skip rendering the item if valueIndex is 6
+                                    if (valueIndex === 6) {
+                                        return null
+                                    }
+
+                                    return (
+                                        <>
+                                            {console.log({ value }, valueIndex)}
+                                            <HeadsContainer key={'row-item-' + valueIndex}>
+                                                <ListItem index={valueIndex}>
+                                                    <ListItemLabel>{colums[valueIndex]?.name}</ListItemLabel>
+                                                    {value}
+                                                </ListItem>
+                                            </HeadsContainer>
+                                        </>
+                                    )
+                                })}
                             </List>
                         ))}
                     </ListContainer>

--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -95,11 +95,6 @@ const Analytics = () => {
                     'Next system price of the collateral, this value is already quoted, and will impact the system on the next price update.',
             },
             { name: 'Stability Fee', description: 'Annual interest rate paid by Safe owners on their debt.' },
-            // {
-            //     name: 'Borrow Rate',
-            //     description:
-            //         'Total annual interest paid by Safe owners on their debt, includes "Stability Fee" and "Annual Redemption Rate".',
-            // },
             { name: 'Total Debt', description: 'Total amount of OD minted per collateral.' },
             {
                 name: 'Debt Utilization',

--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -498,13 +498,7 @@ const AnaliticsBottom = styled.div`
     `}
 `
 
-const LeftColumn = styled.div``
-
 const RightColumn = styled.div``
-
-const LeftTopRow = styled.div`
-    margin-bottom: 24px;
-`
 
 const FlexMultipleRow = styled.div`
     display: flex;

--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -95,11 +95,11 @@ const Analytics = () => {
                     'Next system price of the collateral, this value is already quoted, and will impact the system on the next price update.',
             },
             { name: 'Stability Fee', description: 'Annual interest rate paid by Safe owners on their debt.' },
-            {
-                name: 'Borrow Rate',
-                description:
-                    'Total annual interest paid by Safe owners on their debt, includes "Stability Fee" and "Annual Redemption Rate".',
-            },
+            // {
+            //     name: 'Borrow Rate',
+            //     description:
+            //         'Total annual interest paid by Safe owners on their debt, includes "Stability Fee" and "Annual Redemption Rate".',
+            // },
             { name: 'Total Debt', description: 'Total amount of OD minted per collateral.' },
             {
                 name: 'Debt Utilization',
@@ -252,7 +252,7 @@ const Analytics = () => {
         redemptionPriceData,
         liquidityUniswap,
         annualRedemptionRate,
-        eightHourlyRedemptionRate
+        eightHourlyRedemptionRate,
         // marketPriceODG,
     ]
 

--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -278,6 +278,7 @@ const Analytics = () => {
                                 value?.currentPrice?.toString()
                             )
                             totalLockedValue = totalLockedValue.add(lockedAmountInUsd)
+
                             return [
                                 key,
                                 [
@@ -286,7 +287,6 @@ const Analytics = () => {
                                     <AddressLink address={value?.delayedOracle} chainId={chainId || 420} />,
                                     formatDataNumber(value?.currentPrice?.toString() || '0', 18, 2, true),
                                     formatDataNumber(value?.nextPrice?.toString() || '0', 18, 2, true),
-                                    transformToAnnualRate(value?.stabilityFee?.toString() || '0', 27),
                                     transformToAnnualRate(
                                         multiplyRates(
                                             value?.stabilityFee?.toString(),

--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -161,12 +161,6 @@ const Analytics = () => {
         description: 'Vault NFTs',
     }
 
-    const annualStabilityFee = {
-        title: 'Annual Stability fee',
-        value: '2.0%',
-        description: 'Mock dada for Annual Stability fee',
-    }
-
     const circulation = { title: 'circulation', value: erc20Supply, description: 'Circulation' }
 
     const liquidityUniswap = {
@@ -245,8 +239,6 @@ const Analytics = () => {
         vaultNFTs,
     ]
 
-    const systemRatesData = [annualStabilityFee, annualRedemptionRate, eightHourlyRedemptionRate]
-
     const systemInfoData: DataCardProps[] = [
         circulation,
         // feesPendingAuction,
@@ -259,6 +251,8 @@ const Analytics = () => {
         marketPriceData, // check for market price OD not OD
         redemptionPriceData,
         liquidityUniswap,
+        annualRedemptionRate,
+        eightHourlyRedemptionRate
         // marketPriceODG,
     ]
 
@@ -376,30 +370,6 @@ const Analytics = () => {
                         ))}
                 </AnaliticsTop>
                 <AnaliticsMiddle>
-                    {systemRatesData && (
-                        <LeftColumn>
-                            <SubTitle>System Rates</SubTitle>
-                            <LeftTopRow>
-                                <DataCard
-                                    title={systemRatesData[0].title}
-                                    value={systemRatesData[0].value}
-                                    description={systemRatesData[0].description}
-                                />
-                            </LeftTopRow>
-                            <FlexMultipleRow>
-                                <DataCard
-                                    title={systemRatesData[1].title}
-                                    value={systemRatesData[1].value}
-                                    description={systemRatesData[1].description}
-                                />
-                                <DataCard
-                                    title={systemRatesData[2].title}
-                                    value={systemRatesData[2].value}
-                                    description={systemRatesData[2].description}
-                                />
-                            </FlexMultipleRow>
-                        </LeftColumn>
-                    )}
                     {systemInfoData && (
                         <RightColumn>
                             <SubTitle>System Info</SubTitle>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -19,7 +19,7 @@ export const MULTICALL2_ADDRESSES: AddressMap = {
 export enum Network {
     ARBITRUM = 'arbitrum',
     ARBITRUM_SEPOLIA = 'arbitrum-sepolia',
-    OPTIMISM = 'optimism'
+    OPTIMISM = 'optimism',
 }
 
 const getNetwork = (): Network => {


### PR DESCRIPTION
Closes #321 
- Removed Annual Stability Fee
- Moved Redemption Rates to Price
- Removed column Borrow rate

<img width="1166" alt="Screenshot 2024-04-05 at 1 14 46 PM" src="https://github.com/open-dollar/od-app/assets/36742189/1f991547-be7d-450b-abb9-baf768abe735">

<img width="1178" alt="Screenshot 2024-04-05 at 2 08 02 PM" src="https://github.com/open-dollar/od-app/assets/36742189/f8fcfdf1-f862-47de-8f4f-54079fc5c78b">


