### PR TITLE
Issue #330: Always show interactive element for vaults

### DIFF
--- a/src/containers/Vaults/VaultDetails.tsx
+++ b/src/containers/Vaults/VaultDetails.tsx
@@ -134,9 +134,7 @@ const VaultDetails = ({ ...props }) => {
                 ) : null}
 
                 {/* Users can only repay debt from a vault they don't own */}
-                {!isLoading && !isOwner ? (
-                    <ModifyVault vaultId={safeId} isDeposit={false} isOwner={isOwner} />
-                ) : null}
+                {!isLoading && !isOwner ? <ModifyVault vaultId={safeId} isDeposit={false} isOwner={isOwner} /> : null}
             </Container>
             <Stats />
         </>

--- a/src/containers/Vaults/VaultDetails.tsx
+++ b/src/containers/Vaults/VaultDetails.tsx
@@ -129,8 +129,13 @@ const VaultDetails = ({ ...props }) => {
                     <VaultStats isModifying={isDeposit || isWithdraw} isDeposit={isDeposit} isOwner={isOwner} />
                 )}
 
-                {(isDeposit || isWithdraw) && !isLoading ? (
+                {(isDeposit || isWithdraw) && !isLoading && isOwner ? (
                     <ModifyVault vaultId={safeId} isDeposit={isDeposit} isOwner={isOwner} />
+                ) : null}
+
+                {/* Users can only repay debt from a vault they don't own */}
+                {!isLoading && !isOwner ? (
+                    <ModifyVault vaultId={safeId} isDeposit={false} isOwner={isOwner} />
                 ) : null}
             </Container>
             <Stats />

--- a/src/utils/i18n/en.json
+++ b/src/utils/i18n/en.json
@@ -115,7 +115,7 @@
     "surplus_auction_claim_tokens_desc": "In case someone outbids you in a surplus auction, your ODG bid will be reimbursed to your Open Dollar Account. Claim Tokens can be used to get back ODG (and OD) that is kept in your Account.",
     "migrate": "Migrate",
     "manage_other_safes": "View / Top-up Other Vaults",
-    "managed_safe_warning": "CAUTION: You are not the owner of this Vault. You can only deposit collateral or repay debt. Note that these operations are irreversible.",
+    "managed_safe_warning": "CAUTION: You are not the owner of this Vault. You can only repay debt. Note that these operations are irreversible.",
     "liquidate_safe_warning": "CAUTION: You are about to start the liquidation of this Vault. Note that this operation is irreversible.",
     "liquidate_confirmation": "I understand that I am about to liquidate this Vault.",
     "liquidate_button": "Liquidate Vault #",


### PR DESCRIPTION
Closes #330 

## Description
- Modifies managed_safe_warning to explain users who don't own the vault can only repay that vault
- New rendering logic for ModifySafe component that check isOwner and either enable only repay (if not owner) or enable everything (if owner)

## Screenshots

User can only repay when not owner (can't click on deposit and borrow tab either)

https://github.com/open-dollar/od-app/assets/47253537/2f67cffd-24d6-442e-9196-5abe1ba6bd6c

