### PR TITLE
Prevent Network Errors on switch chain

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -76,7 +76,7 @@ export const TESTNET_CHAINS: ChainConfig = {
         name: 'Arbitrum Sepolia',
         nativeCurrency: ETH,
         blockExplorerUrls: ['https://sepolia.arbiscan.io/'],
-    }
+    },
 }
 
 const supportedChainId = parseInt(process.env.REACT_APP_NETWORK_ID || '', 10)

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -17,8 +17,10 @@ import { fetchPoolData } from '@opendollar/sdk'
 import { fetchAnalyticsData } from '@opendollar/sdk/lib/virtual/virtualAnalyticsData'
 import useGeb from '~/hooks/useGeb'
 import { BigNumber, ethers } from 'ethers'
+import { useActiveWeb3React } from '~/hooks'
 
 const Navbar = () => {
+    const { chainId } = useActiveWeb3React()
     const [isPopupVisible, setPopupVisibility] = useState(false)
     const [state, setState] = useState({
         odPrice: '',
@@ -136,6 +138,7 @@ const Navbar = () => {
     }, [connectWalletModel.tokensFetchedData])
 
     useEffect(() => {
+        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return;
         async function fetchData() {
             if (geb) {
                 try {
@@ -171,7 +174,7 @@ const Navbar = () => {
             document.removeEventListener('mousedown', handleClickOutsideTestToken)
             document.removeEventListener('mousedown', handleClickOutsideOdWallet)
         }
-    }, [geb])
+    }, [geb, chainId])
 
     return (
         <Container>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -138,7 +138,7 @@ const Navbar = () => {
     }, [connectWalletModel.tokensFetchedData])
 
     useEffect(() => {
-        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return;
+        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return
         async function fetchData() {
             if (geb) {
                 try {

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -129,7 +129,7 @@ const SideMenu = () => {
     }
 
     useEffect(() => {
-        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return;
+        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return
         async function fetchData() {
             if (geb) {
                 try {

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -129,6 +129,7 @@ const SideMenu = () => {
     }
 
     useEffect(() => {
+        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return;
         async function fetchData() {
             if (geb) {
                 try {
@@ -165,7 +166,7 @@ const SideMenu = () => {
             document.removeEventListener('mousedown', handleClickOutsideTestToken)
             document.removeEventListener('mousedown', handleClickOutsideOdWallet)
         }
-    }, [geb])
+    }, [geb, chainId])
 
     useEffect(() => {
         setIsOpen(popupsState.showSideMenu)

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -144,7 +144,7 @@ export default function WalletModal() {
             setWalletView(WALLET_VIEWS.ACCOUNT)
         }
     }, [setWalletView, isActive, connector, isConnectorsWalletOpen, activePrevious, connectorPrevious])
-    
+
     function getHeaderContent() {
         if (process.env.REACT_APP_NETWORK_ID === '42161') {
             return (
@@ -164,7 +164,7 @@ export default function WalletModal() {
                     </a>
                 </h5>
             )
-        }  else if (process.env.REACT_APP_NETWORK_ID === '420') {
+        } else if (process.env.REACT_APP_NETWORK_ID === '420') {
             return (
                 <h5>
                     {t('not_supported')}{' '}
@@ -173,7 +173,6 @@ export default function WalletModal() {
                     </a>
                 </h5>
             )
-
         } else {
             return (
                 <h5>
@@ -193,9 +192,7 @@ export default function WalletModal() {
                 {String(chainId) !== process.env.REACT_APP_NETWORK_ID && chainId !== undefined ? (
                     <>
                         <HeaderRow>{'Wrong Network'}</HeaderRow>
-                        <ContentWrapper>
-                            {getHeaderContent()}
-                        </ContentWrapper>
+                        <ContentWrapper>{getHeaderContent()}</ContentWrapper>
                     </>
                 ) : (
                     <HeaderRow>

--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -319,7 +319,7 @@ const Shared = ({ children, ...rest }: Props) => {
             )
             return
         }
-        
+
         if (document.querySelector('#networkToastHash') !== null) {
             document.querySelector('#networkToastHash')?.remove()
         }
@@ -341,7 +341,7 @@ const Shared = ({ children, ...rest }: Props) => {
 
     useEffect(() => {
         if (chainId && chainId === NETWORK_ID) {
-            toast.dismiss(toastId);
+            toast.dismiss(toastId)
         }
         if (chainId && chainId !== NETWORK_ID) {
             const id: ChainId = NETWORK_ID

--- a/src/containers/Vaults/Stats.js
+++ b/src/containers/Vaults/Stats.js
@@ -7,9 +7,11 @@ import { formatDataNumber, multiplyWad } from '~/utils'
 import useGeb from '~/hooks/useGeb'
 import { fetchPoolData } from '@opendollar/sdk'
 import { BigNumber } from 'ethers'
+import { useActiveWeb3React } from '~/hooks'
 
 const Stats = () => {
     const geb = useGeb()
+    const { chainId } = useActiveWeb3React()
     const [state, setState] = useState({
         totalVaults: '',
         wETHBalance: '',
@@ -18,6 +20,7 @@ const Stats = () => {
     })
 
     useEffect(() => {
+        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return;
         async function fetchData() {
             if (geb) {
                 let totalLockedValue = BigNumber.from('0')
@@ -44,7 +47,7 @@ const Stats = () => {
         }
 
         fetchData()
-    }, [geb])
+    }, [geb, chainId])
 
     return (
         <ComponentContainer>

--- a/src/containers/Vaults/Stats.js
+++ b/src/containers/Vaults/Stats.js
@@ -20,7 +20,7 @@ const Stats = () => {
     })
 
     useEffect(() => {
-        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return;
+        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return
         async function fetchData() {
             if (geb) {
                 let totalLockedValue = BigNumber.from('0')

--- a/src/containers/Vaults/index.tsx
+++ b/src/containers/Vaults/index.tsx
@@ -11,7 +11,7 @@ import VaultList from './VaultList'
 const OnBoarding = ({ ...props }) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_isOwner, setIsOwner] = useState(true)
-    const { account, provider } = useActiveWeb3React()
+    const { account, provider, chainId } = useActiveWeb3React()
     const geb = useGeb()
 
     const {
@@ -24,6 +24,7 @@ const OnBoarding = ({ ...props }) => {
     const address: string = props.match.params.address ?? ''
 
     useEffect(() => {
+        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return;
         if (
             (!account && !address) ||
             (address && !isAddress(address.toLowerCase())) ||
@@ -31,7 +32,7 @@ const OnBoarding = ({ ...props }) => {
             connectWalletState.isWrongNetwork
         )
             return
-
+        
         async function fetchSafes() {
             await safeActions.fetchUserSafes({
                 address: address || (account as string),
@@ -56,7 +57,7 @@ const OnBoarding = ({ ...props }) => {
         }, ms)
 
         return () => clearInterval(interval)
-    }, [account, address, connectWalletState.isWrongNetwork, connectWalletState.tokensData, geb, provider, safeActions])
+    }, [account, address, connectWalletState.isWrongNetwork, connectWalletState.tokensData, geb, provider, safeActions, chainId])
 
     useEffect(() => {
         if (account && address) {

--- a/src/containers/Vaults/index.tsx
+++ b/src/containers/Vaults/index.tsx
@@ -24,7 +24,7 @@ const OnBoarding = ({ ...props }) => {
     const address: string = props.match.params.address ?? ''
 
     useEffect(() => {
-        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return;
+        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return
         if (
             (!account && !address) ||
             (address && !isAddress(address.toLowerCase())) ||
@@ -32,7 +32,7 @@ const OnBoarding = ({ ...props }) => {
             connectWalletState.isWrongNetwork
         )
             return
-        
+
         async function fetchSafes() {
             await safeActions.fetchUserSafes({
                 address: address || (account as string),
@@ -57,7 +57,16 @@ const OnBoarding = ({ ...props }) => {
         }, ms)
 
         return () => clearInterval(interval)
-    }, [account, address, connectWalletState.isWrongNetwork, connectWalletState.tokensData, geb, provider, safeActions, chainId])
+    }, [
+        account,
+        address,
+        connectWalletState.isWrongNetwork,
+        connectWalletState.tokensData,
+        geb,
+        provider,
+        safeActions,
+        chainId,
+    ])
 
     useEffect(() => {
         if (account && address) {

--- a/src/hooks/useGeb.ts
+++ b/src/hooks/useGeb.ts
@@ -5,6 +5,7 @@ import { IODSafeManager } from '@opendollar/sdk/lib/typechained'
 import store, { useStoreActions, useStoreState } from '~/store'
 import { EMPTY_ADDRESS, network_name } from '~/utils/constants'
 import { formatNumber } from '~/utils/helper'
+import { GebDeployment } from '@opendollar/sdk'
 import { useActiveWeb3React } from '~/hooks'
 import { NETWORK_ID } from '~/connectors'
 
@@ -18,7 +19,7 @@ export default function useGeb(): Geb {
 
     useEffect(() => {
         if (!provider) return
-        const geb = new Geb(network_name(), provider.getSigner())
+        const geb = new Geb(network_name() as GebDeployment, provider.getSigner())
         setState(geb)
     }, [provider])
 

--- a/src/utils/auctions.ts
+++ b/src/utils/auctions.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers'
-import { Geb } from '@opendollar/sdk'
+import { Geb, GebDeployment } from '@opendollar/sdk'
 import { JsonRpcSigner } from '@ethersproject/providers'
 
 import { IAuctionBid } from '~/types'
@@ -19,7 +19,7 @@ export const handleAuctionBuy = async ({ signer, haiAmount, auctionId, collatera
         return false
     }
 
-    const geb = new Geb(ETH_NETWORK, signer)
+    const geb = new Geb(ETH_NETWORK as GebDeployment, signer)
     const proxy = await geb.getProxyAction(signer._address)
     const haiAmountBN = ethers.utils.parseUnits(haiAmount, 18)
     const collateralAmountBN = ethers.utils.parseUnits(collateralAmount, 18)
@@ -39,7 +39,7 @@ export const handleAuctionBid = async ({ signer, bid, auctionId, auctionType }: 
         return false
     }
 
-    const geb = new Geb(ETH_NETWORK, signer)
+    const geb = new Geb(ETH_NETWORK as GebDeployment, signer)
     const proxy = await geb.getProxyAction(signer._address)
     const bidBN = ethers.utils.parseEther(bid)
 
@@ -63,7 +63,7 @@ export const handleAuctionClaim = async ({ signer, auctionId, auctionType }: IAu
     if (!signer || !auctionId || !auctionType) {
         return false
     }
-    const geb = new Geb(ETH_NETWORK, signer)
+    const geb = new Geb(ETH_NETWORK as GebDeployment, signer)
     const proxy = await geb.getProxyAction(signer._address)
 
     let tx
@@ -89,7 +89,7 @@ export const handleClaimInternalBalance = async ({ signer, type, bid: amount, to
     if (!signer) {
         return false
     }
-    const geb = new Geb(ETH_NETWORK, signer)
+    const geb = new Geb(ETH_NETWORK as GebDeployment, signer)
     const proxy = await geb.getProxyAction(signer._address)
     console.log({ signer, type, bid: amount, token })
     let txData: ethers.PopulatedTransaction

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -19,7 +19,7 @@ export const MULTICALL2_ADDRESSES: AddressMap = {
 export enum Network {
     ARBITRUM = 'arbitrum',
     ARBITRUM_SEPOLIA = 'arbitrum-sepolia',
-    OPTIMISM = 'optimism'
+    OPTIMISM = 'optimism',
 }
 
 const getNetwork = (): Network => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -189,7 +189,7 @@ export const network_name = () => {
     if (process.env.REACT_APP_NETWORK_ID === '42161') return 'arbitrum'
     if (process.env.REACT_APP_NETWORK_ID === '421614') return 'arbitrum-sepolia'
     if (process.env.REACT_APP_NETWORK_ID === '10') return 'optimism'
-    return 'arbitrum-sepolia'
+    else return 'arbitrum-sepolia'
 }
 
 const provider = new ethers.providers.JsonRpcProvider(REACT_APP_NETWORK_URL)

--- a/src/utils/wrapEther.ts
+++ b/src/utils/wrapEther.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import { JsonRpcSigner } from '@ethersproject/providers'
-import { Geb } from '@opendollar/sdk'
+import { Geb, GebDeployment } from '@opendollar/sdk'
 import { ETH_NETWORK } from './constants'
 
 export interface WrapEtherProps {
@@ -13,7 +13,7 @@ export const handleWrapEther = async ({ signer, amount }: WrapEtherProps) => {
         return false
     }
 
-    const geb = new Geb(ETH_NETWORK, signer)
+    const geb = new Geb(ETH_NETWORK as GebDeployment, signer)
 
     const amountBN = ethers.utils.parseEther(amount)
     const tx = await geb.contracts.weth.populateTransaction.deposit({ value: amountBN })


### PR DESCRIPTION
closes #335 

A few issues surfaced in this PR:

1. Typing for Geb was not correct, Network should be GebDeployment
2. There were no checks to see if the network switched to are supported prior to triggering functions
3. Too many functions are being triggered when geb changes
4. The Network error warning did not disappear after switching to correct chain

Additionally I noticed the overuse of the useEffect hook:
https://react.dev/learn/you-might-not-need-an-effect

Cleaning that up can come later, but 9 in 1 file is too much, and there too many hooks which are copy pasted in multiple files.