### PR TITLE
Issue #298: App Redesign: Upper part of modify vault page

### DIFF
--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -109,8 +109,6 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                     style={{
                                         maxWidth: '100%',
                                         height: 'auto',
-                                        border: '1px solid #00374E',
-                                        borderRadius: '0px',
                                     }}
                                     dangerouslySetInnerHTML={{ __html: svg }}
                                 ></div>
@@ -121,10 +119,7 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
 
                 <Right>
                     <Inner>
-                        <Side style={{ borderTop: '1px solid #00587E', paddingTop: '8px' }}>
-                            <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('debt_owed_tip')}>
-                                <Info size="16" />
-                            </InfoIcon>
+                        <Side>
                             <SideTitle>
                                 Debt Owed
                                 {modified ? (
@@ -136,18 +131,15 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                     </div>
                                 ) : null}
                             </SideTitle>
+                            <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('debt_owed_tip')}>
+                                <Info size="16" />
+                            </InfoIcon>
                             <SideValue>
                                 {formatWithCommas(totalDebt)} OD
                                 <DollarValue>${formatWithCommas(totalDebtInUSD)}</DollarValue>
                             </SideValue>
                         </Side>
                         <Side>
-                            <InfoIcon
-                                data-tooltip-id="vault-stats"
-                                data-tooltip-content={t('collateral_deposited_tip')}
-                            >
-                                <Info size="16" />
-                            </InfoIcon>
                             <SideTitle>
                                 Collateral Deposited
                                 {modified ? (
@@ -161,18 +153,18 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                     <></>
                                 )}
                             </SideTitle>
-                            <SideValue>
-                                {formatWithCommas(collateral)} {singleSafe?.collateralName}
-                                <DollarValue>${formatWithCommas(collateralInUSD, 2, 2)}</DollarValue>
-                            </SideValue>
-                        </Side>
-                        <Side>
                             <InfoIcon
                                 data-tooltip-id="vault-stats"
                                 data-tooltip-content={t('collateral_deposited_tip')}
                             >
                                 <Info size="16" />
                             </InfoIcon>
+                            <SideValue>
+                                {formatWithCommas(collateral)} {singleSafe?.collateralName}
+                                <DollarValue>${formatWithCommas(collateralInUSD, 2, 2)}</DollarValue>
+                            </SideValue>
+                        </Side>
+                        <Side>
                             <SideTitle>
                                 Collateral Ratio (min {collateralRatio}%)
                                 <div>
@@ -242,28 +234,31 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                     <></>
                                 )}
                             </SideTitle>
+                            <InfoIcon
+                                data-tooltip-id="vault-stats"
+                                data-tooltip-content={t('collateral_deposited_tip')}
+                            >
+                                <Info size="16" />
+                            </InfoIcon>
                             <SideValue>{singleSafe ? formatWithCommas(singleSafe?.collateralRatio) : '-'}%</SideValue>
                         </Side>
                         <Side>
+                            <SideTitle>{singleSafe?.collateralName} Price (Delayed)</SideTitle>
                             <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('eth_osm_tip')}>
                                 <Info size="16" />
                             </InfoIcon>
-                            <SideTitle>{singleSafe?.collateralName} Price (Delayed)</SideTitle>
                             <SideValue>${formatWithCommas(collateralUnitPriceUSD, 2, 2)}</SideValue>
                         </Side>
 
                         <Side>
+                            <SideTitle>OD Redemption Price</SideTitle>
                             <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('hai_red_price_tip')}>
                                 <Info size="16" />
                             </InfoIcon>
-                            <SideTitle>OD Redemption Price</SideTitle>
                             <SideValue>${ODPrice}</SideValue>
                         </Side>
 
                         <Side>
-                            <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('liquidation_price_tip')}>
-                                <Info size="16" />
-                            </InfoIcon>
                             <SideTitle>
                                 Liquidation Price
                                 {modified ? (
@@ -275,24 +270,27 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                     </div>
                                 ) : null}
                             </SideTitle>
+                            <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('liquidation_price_tip')}>
+                                <Info size="16" />
+                            </InfoIcon>
                             <SideValue>
                                 ${singleSafe ? formatWithCommas(singleSafe.liquidationPrice, 2, 2) : '-'}
                             </SideValue>
                         </Side>
 
                         <Side>
+                            <SideTitle>Liquidation Penalty</SideTitle>
                             <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('liquidation_penalty_tip')}>
                                 <Info size="16" />
                             </InfoIcon>
-                            <SideTitle>Liquidation Penalty</SideTitle>
                             <SideValue>{`${liquidationPenalty}%`}</SideValue>
                         </Side>
 
                         <Side>
+                            <SideTitle>Stability Fee</SideTitle>
                             <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('stability_fee_tip')}>
                                 <Info size="16" />
                             </InfoIcon>
-                            <SideTitle>Stability Fee</SideTitle>
                             <SideValue>{`${
                                 singleSafe?.totalAnnualizedStabilityFee
                                     ? getRatePercentage(singleSafe?.totalAnnualizedStabilityFee, 2)
@@ -301,10 +299,10 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                         </Side>
 
                         <Side>
+                            <SideTitle>Annual Redemption Rate</SideTitle>
                             <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('annual_redemption_tip')}>
                                 <Info size="16" />
                             </InfoIcon>
-                            <SideTitle>Annual Redemption Rate</SideTitle>
                             <SideValue>{`${returnRedRate()}%`}</SideValue>
                         </Side>
                     </Inner>
@@ -349,7 +347,7 @@ const InnerLeft = styled.div`
 const Inner = styled.div`
     background: ${(props) => props.theme.colors.colorPrimary};
     padding: 20px;
-    border-radius: 20px;
+    border-radius: 4px;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -369,8 +367,9 @@ const Left = styled.div`
     }
 `
 const Right = styled.div`
+    background: white;
+    border-radius: 4px;
     flex: 0 0 45%;
-    padding-left: 10px;
     margin-top: 20px;
     @media (max-width: 767px) {
         flex: 0 0 100%;
@@ -394,8 +393,7 @@ const Side = styled.div`
     &:last-child {
         margin-bottom: 0;
     }
-    border-bottom: 1px solid #00587e;
-    padding-bottom: 4px;
+    border-bottom: 1px solid rgba(26, 116, 236, 0.3);
     @media (max-width: 767px) {
         padding-top: 4px;
     }
@@ -405,7 +403,8 @@ const Side = styled.div`
 `
 
 const SideTitle = styled.div`
-    color: ${(props) => props.theme.colors.secondary};
+    color: #475662;
+    font-family: 'Open Sans', sans-serif;
     font-size: 16px;
     .sideNote {
         font-size: 12px;
@@ -422,17 +421,19 @@ const SideTitle = styled.div`
 const SideValue = styled.div`
     margin-left: auto;
     text-align: right;
-    color: ${(props) => props.theme.colors.customSecondary};
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 700;
+    color: #475662;
     font-size: 16px;
 `
 
 const InfoIcon = styled.div`
     cursor: pointer;
     svg {
-        fill: ${(props) => props.theme.colors.secondary};
-        color: ${(props) => props.theme.colors.foreground};
+        border: none;
+        color: #475662;
         position: relative;
+        margin-left: 4px;
         top: 4px;
-        margin-right: 5px;
     }
 `

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -14,8 +14,6 @@ import { generateSvg } from '@opendollar/svg-generator'
 const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposit: boolean; isOwner: boolean }) => {
     const { t } = useTranslation()
     const {
-        totalDebt: newDebt,
-        totalCollateral: newCollateral,
         collateralRatio: newCollateralRatio,
         parsedAmounts,
         liquidationPrice: newLiquidationPrice,
@@ -43,8 +41,6 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
         safeState.liquidationData!.collateralLiquidationData[collateralName].currentPrice.value
     )
     const collateralInUSD = formatNumber((Number(collateralUnitPriceUSD) * Number(collateral)).toString())
-    const collateralRatio =
-        Number(safeState.liquidationData!.collateralLiquidationData[collateralName].safetyCRatio) * 100
 
     const liquidationPenalty = getRatePercentage(
         safeState.liquidationData!.collateralLiquidationData[collateralName].liquidationPenalty,
@@ -119,91 +115,47 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
 
                 <Right>
                     <Inner>
-                        <Side>
-                            <SideTitle>
-                                Debt Owed
-                                {modified ? (
-                                    <div className="sideNote">
-                                        After:{' '}
-                                        <span className={isDeposit ? 'green' : 'yellow'}>
-                                            {formatWithCommas(newDebt, 2)}
-                                        </span>
-                                    </div>
-                                ) : null}
-                            </SideTitle>
-                            <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('debt_owed_tip')}>
-                                <Info size="16" />
-                            </InfoIcon>
-                            <SideValue>
-                                {formatWithCommas(totalDebt)} OD
+                        <StatsGrid>
+                            <StatSection>
+                                <StatHeader>
+                                    <StatTitle>Debt Owed</StatTitle>
+                                    <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('debt_owed_tip')}>
+                                        <Info size="16" />
+                                    </InfoIcon>
+                                </StatHeader>
+                                <StatValue>{formatWithCommas(totalDebt)} OD</StatValue>
                                 <DollarValue>${formatWithCommas(totalDebtInUSD)}</DollarValue>
-                            </SideValue>
-                        </Side>
-                        <Side>
-                            <SideTitle>
-                                Collateral Deposited
-                                {modified ? (
-                                    <div className="sideNote">
-                                        After:{' '}
-                                        <span className={isDeposit ? 'green' : 'yellow'}>
-                                            {formatWithCommas(newCollateral)}
-                                        </span>
-                                    </div>
-                                ) : (
-                                    <></>
-                                )}
-                            </SideTitle>
-                            <InfoIcon
-                                data-tooltip-id="vault-stats"
-                                data-tooltip-content={t('collateral_deposited_tip')}
-                            >
-                                <Info size="16" />
-                            </InfoIcon>
-                            <SideValue>
-                                {formatWithCommas(collateral)} {singleSafe?.collateralName}
+                            </StatSection>
+                            <StatSection>
+                                <StatHeader>
+                                    <StatTitle>Collateral Deposited</StatTitle>
+                                    <InfoIcon
+                                        data-tooltip-id="vault-stats"
+                                        data-tooltip-content={t('collateral_deposited_tip')}
+                                    >
+                                        <Info size="16" />
+                                    </InfoIcon>
+                                </StatHeader>
+                                <StatValue>
+                                    {formatWithCommas(collateral)} {singleSafe?.collateralName}
+                                </StatValue>
                                 <DollarValue>${formatWithCommas(collateralInUSD, 2, 2)}</DollarValue>
-                            </SideValue>
-                        </Side>
-                        <Side>
-                            <SideTitle>
-                                Collateral Ratio (min {collateralRatio}%)
-                                <div>
-                                    <span
-                                        style={{
-                                            color: '#FCBF3B',
-                                            fontSize: '12px',
-                                            fontWeight: '400',
-                                            lineHeight: '15.6px',
-                                            opacity: '60%',
-                                        }}
+                            </StatSection>
+                            <StatSection>
+                                <StatHeader>
+                                    <StatTitle>Collateral Ratio</StatTitle>
+                                    <InfoIcon
+                                        data-tooltip-id="vault-stats"
+                                        data-tooltip-content={t('collateral_ratio_tip')}
                                     >
-                                        Safety:{' '}
-                                        {Number(
-                                            safeState.liquidationData!.collateralLiquidationData[collateralName]
-                                                .safetyCRatio
-                                        ) * 100}
-                                        %
-                                    </span>{' '}
-                                    &nbsp;
-                                    <span
-                                        style={{
-                                            color: '#E45200',
-                                            fontSize: '12px',
-                                            fontWeight: '400',
-                                            lineHeight: '15.6px',
-                                            opacity: '60%',
-                                        }}
-                                    >
-                                        Minimum:{' '}
-                                        {Number(
-                                            safeState.liquidationData!.collateralLiquidationData[collateralName]
-                                                .liquidationCRatio
-                                        ) * 100}
-                                        %
-                                    </span>
-                                </div>
+                                        <Info size="16" />
+                                    </InfoIcon>
+                                </StatHeader>
+                                <StatValue>
+                                    {singleSafe ? formatWithCommas(singleSafe?.collateralRatio) : '-'}%
+                                </StatValue>
                                 {modified ? (
-                                    <div className="sideNote">
+                                    <DollarValue className="sideNote">
                                         After:{' '}
                                         <span
                                             className={
@@ -229,19 +181,45 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                                         >
                                             {formatWithCommas(newCollateralRatio)}%
                                         </span>
-                                    </div>
+                                    </DollarValue>
                                 ) : (
                                     <></>
                                 )}
-                            </SideTitle>
-                            <InfoIcon
-                                data-tooltip-id="vault-stats"
-                                data-tooltip-content={t('collateral_deposited_tip')}
-                            >
-                                <Info size="16" />
-                            </InfoIcon>
-                            <SideValue>{singleSafe ? formatWithCommas(singleSafe?.collateralRatio) : '-'}%</SideValue>
-                        </Side>
+                                <div>
+                                    <span
+                                        style={{
+                                            color: '#FFAF1D',
+                                            fontSize: '12px',
+                                            fontWeight: '400',
+                                            lineHeight: '15.6px',
+                                        }}
+                                    >
+                                        Safety:{' '}
+                                        {Number(
+                                            safeState.liquidationData!.collateralLiquidationData[collateralName]
+                                                .safetyCRatio
+                                        ) * 100}
+                                        %
+                                    </span>{' '}
+                                    &nbsp;
+                                    <span
+                                        style={{
+                                            color: '#E75966',
+                                            fontSize: '12px',
+                                            fontWeight: '400',
+                                            lineHeight: '15.6px',
+                                        }}
+                                    >
+                                        Minimum:{' '}
+                                        {Number(
+                                            safeState.liquidationData!.collateralLiquidationData[collateralName]
+                                                .liquidationCRatio
+                                        ) * 100}
+                                        %
+                                    </span>
+                                </div>
+                            </StatSection>
+                        </StatsGrid>
                         <Side>
                             <SideTitle>{singleSafe?.collateralName} Price (Delayed)</SideTitle>
                             <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('eth_osm_tip')}>
@@ -249,7 +227,6 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
                             </InfoIcon>
                             <SideValue>${formatWithCommas(collateralUnitPriceUSD, 2, 2)}</SideValue>
                         </Side>
-
                         <Side>
                             <SideTitle>OD Redemption Price</SideTitle>
                             <InfoIcon data-tooltip-id="vault-stats" data-tooltip-content={t('hai_red_price_tip')}>
@@ -316,6 +293,54 @@ const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposi
 
 export default VaultStats
 
+const StatsGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, 1fr);
+    width: 100%;
+    white-space: nowrap;
+    .sideNote {
+        font-size: 12px;
+        span {
+            &.green {
+                color: ${(props) => props.theme.colors.blueish};
+            }
+            &.yellow {
+                color: ${(props) => props.theme.colors.yellowish};
+            }
+        }
+    }
+`
+
+const StatHeader = styled.div`
+    display: flex;
+    align-items: start;
+    justify-content: start;
+    width: 100%;
+    white-space: nowrap;
+`
+
+const StatSection = styled.div`
+    display: flex;
+    flex-direction: column;
+    min-height: 98px;
+    align-items: start;
+    justify-content: start;
+    text-align: start;
+`
+
+const StatTitle = styled.div`
+    font-size: 16px;
+    color: #475662;
+    margin-right: 10px;
+`
+
+const StatValue = styled.div`
+    font-size: 18px;
+    font-weight: 700;
+    margin-top: 5px;
+`
+
 const SVGContainer = styled.div`
     display: flex;
     align-items: center;
@@ -335,6 +360,8 @@ const Flex = styled.div`
     display: flex;
     @media (max-width: 767px) {
         flex-direction: column;
+        justify-items: center;
+        align-items: center;
     }
 `
 
@@ -371,9 +398,13 @@ const Right = styled.div`
     border-radius: 4px;
     flex: 0 0 45%;
     margin-top: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    max-width: 420px;
     @media (max-width: 767px) {
         flex: 0 0 100%;
-        padding-left: 0;
+        padding: 10px;
     }
 `
 
@@ -384,8 +415,8 @@ const Main = styled.div`
 `
 
 const DollarValue = styled.div`
-    font-size: 13px;
-    color: ${(props) => props.theme.colors.blueish};
+    font-size: 12px;
+    color: #475662;
 `
 
 const Side = styled.div`
@@ -406,6 +437,7 @@ const SideTitle = styled.div`
     color: #475662;
     font-family: 'Open Sans', sans-serif;
     font-size: 16px;
+    margin-right: 4px;
     .sideNote {
         font-size: 12px;
         span {
@@ -432,8 +464,6 @@ const InfoIcon = styled.div`
     svg {
         border: none;
         color: #475662;
-        position: relative;
-        margin-left: 4px;
-        top: 4px;
+        margin-top: 4px;
     }
 `

--- a/src/containers/Vaults/VaultDetails.tsx
+++ b/src/containers/Vaults/VaultDetails.tsx
@@ -145,7 +145,7 @@ export default VaultDetails
 
 const Container = styled.div`
     max-width: 880px;
-    margin: 80px auto;
+    margin: 50px auto;
     padding: 0 15px;
     @media (max-width: 767px) {
         margin: 50px auto;

--- a/src/containers/Vaults/VaultHeader.tsx
+++ b/src/containers/Vaults/VaultHeader.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { ArrowLeft } from 'react-feather'
+import { ChevronLeft } from 'react-feather'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -20,13 +20,13 @@ const VaultHeader = ({ safeId }: { safeId: string }) => {
     return (
         <Container>
             <BackBtn id="back-btn" onClick={handleBack}>
-                <ArrowLeft size="16" /> Back
+                <ChevronLeft size={18} /> BACK
             </BackBtn>
             <HeaderContainer>
                 <LeftSide>
                     <SafeInfo>
                         <UpperInfo>
-                            {singleSafe?.collateralName} Vault <span>#{safeId}</span>
+                            {singleSafe?.collateralName} Vault <VaultNumberContainer>#{safeId}</VaultNumberContainer>
                         </UpperInfo>
                     </SafeInfo>
                 </LeftSide>
@@ -46,13 +46,26 @@ const VaultHeader = ({ safeId }: { safeId: string }) => {
 
 export default VaultHeader
 
-const Container = styled.div``
+const Container = styled.div`
+    padding-left: 18px;
+`
+
+const VaultNumberContainer = styled.span`
+    font-size: 30px;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 700;
+    color: #1a74ec;
+    margin-left: 10px;
+`
 
 const BackBtn = styled.div`
     margin-bottom: 20px;
+    font-size: 16px;
     display: flex;
     align-items: center;
-    color: ${(props) => props.theme.colors.secondary};
+    font-weight: 700;
+    font-family: 'Open Sans', sans-serif;
+    color: #1c293a;
     cursor: pointer;
     max-width: fit-content;
     svg {
@@ -129,9 +142,8 @@ const SafeInfo = styled.div``
 const UpperInfo = styled.div`
     font-size: 34px;
     font-weight: 700;
+    font-family: 'Barlow', sans-serif;
     min-width: 180px;
-    span {
-        color: ${(props) => props.theme.colors.blueish};
-    }
+    color: #1c293a;
     margin-bottom: 40px;
 `


### PR DESCRIPTION
Closes #298 

## Description
- Adds upper part of modify vault page

Differences from design:

- The border radius and size of the SVG are different in the design, but in order for us to change these we need to change them in the svg-generator which may or may not cause issues with the formatting of svg itself. I'd say we should avoid doing this because changing the size may warp the inside parts of the svg and the only difference it makes in the design is the border radius of the svg isn't 4px and the padding on the right-side part of the page (with all the vault stats in it) does not have as much padding as in the design
- We decided not to make the vault safety component (https://github.com/open-dollar/od-app/issues/296) so I just preserved the same list design that we had (but with updated fonts, colors, etc). I don't know if we want to add in some blue text or row structure to emphasize certain parts of the text (see below) but for now I left it as the same list as we had

<img width="379" alt="Screenshot 2024-04-18 at 6 54 43 PM" src="https://github.com/open-dollar/od-app/assets/47253537/6a3fbc95-840b-4e13-9ff4-bb3b4b8b193e">

## Screenshots

Desktop

<img width="1437" alt="desktop" src="https://github.com/open-dollar/od-app/assets/47253537/3c539ad6-f127-4816-8d1d-15285b41d210">

Mobile 1

<img width="561" alt="mobile 1" src="https://github.com/open-dollar/od-app/assets/47253537/11a8f083-b5de-4a85-8ea3-c101d7e000e4">

Mobile 2

<img width="548" alt="mobile 2" src="https://github.com/open-dollar/od-app/assets/47253537/c71e846c-9901-4c98-a5ad-cb01ec20cf29">

Demo

https://github.com/open-dollar/od-app/assets/47253537/bd9b82a5-2987-46e9-9f53-57c2ec8e4128



