### PR TITLE
Issue #384: QA - Web Redesign (Part 4)

### DIFF
--- a/src/components/ConnectedWalletInfo.tsx
+++ b/src/components/ConnectedWalletInfo.tsx
@@ -67,7 +67,7 @@ const ConnectedWalletInfo = () => {
             <DataContainer>
                 <Connection>
                     {t('connected_with')} {connector ? formatConnectorName() : 'N/A'}
-                    <Button text={'change'} onClick={handleChange} />
+                    <Button text={'change'} disabled={connector instanceof MetaMask} onClick={handleChange} />
                 </Connection>
                 <Address id="web3-account-identifier-row">
                     <ConnectedWalletIcon size={20} />

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -17,8 +17,8 @@ const CookieBanner = () => {
                     <CookiesText>
                         <p>
                             This website uses cookies to enhance the user experience. By continuing to browse the site
-                            you're agreeing to our &nbsp;
-                            <a target="_blank" href="https://opendollar.com/tos" rel="noreferrer">
+                            you're agreeing to our{' '}
+                            <a target="_blank" href="https://www.opendollar.com/terms" rel="noreferrer">
                                 use of cookies
                             </a>
                             .

--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -15,7 +15,7 @@ interface Props {
     withArrow?: boolean
     children?: ReactNode
     color?: 'blueish' | 'greenish' | 'yellowish' | 'colorPrimary' | 'colorSecondary'
-    border?: boolean
+    border?: string
 }
 const LinkButton = ({
     id,
@@ -26,7 +26,7 @@ const LinkButton = ({
     withArrow,
     children,
     color = 'blueish',
-    border,
+    border = '',
     ...rest
 }: Props) => {
     return isExternal ? (
@@ -56,7 +56,7 @@ const ExtLink = styled.a`
 const RedesignedBtnStyle = css<{
     disabled?: boolean
     color?: string
-    border?: boolean
+    border?: string
 }>`
     pointer-events: ${({ theme, disabled }) => (disabled ? 'none' : 'inherit')};
     outline: none;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -232,7 +232,7 @@ const Navbar = () => {
                                             width={22}
                                             height={22}
                                         />
-                                        tokens
+                                        Tokens
                                         <ArrowWrapper>
                                             <ArrowDown fill={isTestTokenPopupVisible ? '#1499DA' : '#00587E'} />
                                         </ArrowWrapper>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -408,6 +408,12 @@ const PopupWrapperTokenLink = styled.a`
     color: ${(props) => props.theme.colors.neutral};
     cursor: pointer;
     align-items: center;
+    transition: all 0.3s ease;
+    border-radius: 4px;
+
+    &:hover {
+        background-color: #f2f2f2;
+    }
 `
 
 const screenWidth = '1073px'

--- a/src/components/ToastPayload.tsx
+++ b/src/components/ToastPayload.tsx
@@ -44,7 +44,7 @@ const Container = styled.div`
     display: flex;
     align-items: center;
     padding: 10px 15px;
-    background-color: ${(props) => props.theme.colors.blueish};
+    background-color: #1a74ec;
     svg {
         margin-right: 15px;
     }

--- a/src/components/VaultBlock.tsx
+++ b/src/components/VaultBlock.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import { returnState, COIN_TICKER, getTokenLogo, formatWithCommas } from '~/utils'
 
 const VaultBlock = ({ ...props }) => {
-    console.log(props.riskState)
     return (
         <Container className={props.className}>
             <Link to={`/vaults/${props.id}/deposit`}>

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -235,11 +235,15 @@ const Wrapper = styled.div`
     border-radius: 2.43px;
     padding: 1rem;
     width: 100%;
+    color: white;
+    font-family: 'Barlow', sans-serif;
 `
 
 const HeaderRow = styled.div`
     text-align: center;
     font-weight: 800;
+    color: white;
+    font-family: 'Open Sans', sans-serif;
 `
 
 const ContentWrapper = styled.div`

--- a/src/containers/Vaults/VaultDetails.tsx
+++ b/src/containers/Vaults/VaultDetails.tsx
@@ -12,7 +12,6 @@ import VaultHeader from './VaultHeader'
 import useGeb from '~/hooks/useGeb'
 import gebManager from '~/utils/gebManager'
 import { ethers } from 'ethers'
-import Stats from '~/containers/Vaults/Stats'
 
 const VaultDetails = ({ ...props }) => {
     const geb = useGeb()
@@ -136,7 +135,6 @@ const VaultDetails = ({ ...props }) => {
                 {/* Users can only repay debt from a vault they don't own */}
                 {!isLoading && !isOwner ? <ModifyVault vaultId={safeId} isDeposit={false} isOwner={isOwner} /> : null}
             </Container>
-            <Stats />
         </>
     )
 }

--- a/src/containers/Vaults/index.tsx
+++ b/src/containers/Vaults/index.tsx
@@ -34,11 +34,15 @@ const OnBoarding = ({ ...props }) => {
             return
 
         async function fetchSafes() {
-            await safeActions.fetchUserSafes({
-                address: address || (account as string),
-                geb,
-                tokensData: connectWalletState.tokensData,
-            })
+            try {
+                await safeActions.fetchUserSafes({
+                    address: address || (account as string),
+                    geb,
+                    tokensData: connectWalletState.tokensData,
+                })
+            } catch (error) {
+                console.debug('Error fetching safes:', error)
+            }
         }
 
         if (geb && connectWalletState.tokensData) {


### PR DESCRIPTION
Closes #384 

## Description
- [X] Change button does nothing

Now disables change button when connected with browser wallet

- [X] No disconnect button

Now disables change button when connected with browser wallet

- [X] - Transactions don't seem to appear:

Create vault is appearing but can't test modify vault until we merge in Sero's ModifyVault.tsx changes

- [X] Warning background is too light, it should also be clickable to change the network automatically

Fixed backgrounds of the toast and modal, we can't do the clickable thing because non-browser wallets don't support this

- [X] Switching from Random chain to OD App chain causes site to break

Added try catches to every network call in Shared.tsx w/debug statements and now we don't get these errors

- [X] TOS Leads nowhere

Link updated

- [X] Cannot repay OD

Sero fixed the ModifyVault.tsx problems in a separate PR

- [X] Add tokens to wallet, needs a hover state

See screenshot

- Fixed border error (we cannot pass a boolean to the border property)

- Added back deleted code to ModifyVault.tsx (I was only able to test this flow once because of this create/modify vault errors mentioned above)

- Fixed node removal error we were getting when switching networks (due to faulty toast removal logic in Shared.tsx)

- Removed Stats component that somehow got back in to dev when we merged dev with epic/web-redesign I think 

## Screenshots

New backgrounds for switch network modal and toast

<img width="914" alt="Screenshot 2024-04-22 at 5 22 30 PM" src="https://github.com/open-dollar/od-app/assets/47253537/7dd683e5-63fd-4591-8a1f-0b822607ec48">

Create vault appears in transaction history

<img width="1202" alt="Screenshot 2024-04-23 at 1 52 24 PM" src="https://github.com/open-dollar/od-app/assets/47253537/bc6b408b-546a-4189-a143-717adde4d1c9">

Add hover effect for adding token

<img width="350" alt="add hover" src="https://github.com/open-dollar/od-app/assets/47253537/e39fc4e0-21a1-447d-a181-0b377964675e">


