### PR TITLE
Issue #403: Lost wallet context when clicking navbar logo

### DIFF
--- a/src/components/Brand.tsx
+++ b/src/components/Brand.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import { useStoreState } from '~/store'
 import DarkFullLogo from '~/assets/od-full-logo-dark.svg'
 import LightFullLogo from '~/assets/od-full-logo-light.svg'
+import { Link } from 'react-router-dom'
 
 const Brand = () => {
     const isLightTheme = useStoreState((state) => state.settingsModel.isLightTheme)
@@ -10,9 +11,9 @@ const Brand = () => {
 
     return (
         <Container>
-            <a href={'/'}>
+            <Link to="/">
                 <img src={LogoComponent} alt="OD" />
-            </a>
+            </Link>
         </Container>
     )
 }

--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -40,7 +40,6 @@ import {
     ChainId,
     IS_IN_IFRAME,
     timeout,
-    SupportedChainId,
 } from '~/utils'
 import LiquidateSafeModal from '~/components/Modals/LiquidateSafeModal'
 import Footer from '~/components/Footer'


### PR DESCRIPTION
Closes #403 

## Description
- Fixed lost wallet context when pressing navbar logo by making the logo an internal route rather than an tag

## Screenshots

Wallet context lost when pressing logo

https://github.com/open-dollar/od-app/assets/47253537/a1af5f32-c27f-41c2-9430-696846e5d06d

No longer losing wallet context when pressing logo

https://github.com/open-dollar/od-app/assets/47253537/a2d183dd-f0c8-4723-84b9-2a8e768a7828

