### PR TITLE
Issue #446: Display stats collateraljoin contracts

### DIFF
--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -83,6 +83,8 @@ const Analytics = () => {
         colums: [
             { name: 'Collateral' },
             { name: 'ERC-20', description: 'Address of the ERC20 collateral token.' },
+            { name: 'Collateral Join', description: 'Address of the collateral join contract.' },
+            { name: 'Auction House', description: 'Address of the collateral auction house.' },
             { name: 'Oracle', description: 'Delayed oracle address for the collateral.' },
             {
                 name: 'Delayed Price',
@@ -280,6 +282,14 @@ const Analytics = () => {
                                 [
                                     key,
                                     <AddressLink address={geb.tokenList[key].address} chainId={chainId || 420} />,
+                                    <AddressLink
+                                        address={geb.tokenList[key]?.collateralJoin}
+                                        chainId={chainId || 420}
+                                    />,
+                                    <AddressLink
+                                        address={geb.tokenList[key]?.collateralAuctionHouse}
+                                        chainId={chainId || 420}
+                                    />,
                                     <AddressLink address={value?.delayedOracle} chainId={chainId || 420} />,
                                     formatDataNumber(value?.currentPrice?.toString() || '0', 18, 2, true),
                                     formatDataNumber(value?.nextPrice?.toString() || '0', 18, 2, true),


### PR DESCRIPTION
Closes #446 

## Description
- Adds collateralJoin and collateralAuctionHouse to collaterals section of analytics page for each collateral

## Screenshots

<img width="1393" alt="collaterals new" src="https://github.com/open-dollar/od-app/assets/47253537/dc984f0e-f376-46fa-a8fa-e1668496278d">

<img width="464" alt="collaterals mobile" src="https://github.com/open-dollar/od-app/assets/47253537/51d737a5-12f2-4c00-b0a7-ee85c62b4bc3">
