### PR TITLE
Remove 5% Buffer On Vault Creation with Max Balance

### DIFF
--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -109,7 +109,7 @@ const CreateVault = ({
         )
     )
     const haiBalanceUSD = useTokenBalanceInUSD('OD', rightInput ? rightInput : availableHai)
-    
+
     //const maxHaiWithBuffer = Math.trunc(+availableHai - (+availableHai * 5) / 100)
     const onMaxLeftInput = () => onLeftInput(selectedTokenBalance.toString())
     //available hai - 5% of available hai, this is a buffer to prevent bugs.

--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -19,6 +19,7 @@ import {
     handleTransactionError,
     useActiveWeb3React,
     useInputsHandlers,
+    useTokenBalanceInUSD,
     useTokenApproval,
     ApprovalState,
     useSafeInfo,
@@ -107,10 +108,12 @@ const CreateVault = ({
             )
         )
     )
-    const maxHaiWithBuffer = Math.trunc(+availableHai - (+availableHai * 5) / 100)
+    const haiBalanceUSD = useTokenBalanceInUSD('OD', rightInput ? rightInput : availableHai)
+    
+    //const maxHaiWithBuffer = Math.trunc(+availableHai - (+availableHai * 5) / 100)
     const onMaxLeftInput = () => onLeftInput(selectedTokenBalance.toString())
     //available hai - 5% of available hai, this is a buffer to prevent bugs.
-    const onMaxRightInput = () => onRightInput(maxHaiWithBuffer.toString())
+    const onMaxRightInput = () => onRightInput(haiBalanceUSD.toString())
 
     const onClearAll = useCallback(() => {
         clearAll()
@@ -309,7 +312,7 @@ const CreateVault = ({
                                             label={`Borrow OD: ${formatWithCommas(availableHai)} ${
                                                 tokensData.OD?.symbol
                                             }`}
-                                            rightLabel={`~$${formatWithCommas(maxHaiWithBuffer)}`}
+                                            rightLabel={`~$${formatWithCommas(haiBalanceUSD)}`}
                                             onChange={onRightInput}
                                             value={rightInput}
                                             handleMaxClick={onMaxRightInput}


### PR DESCRIPTION
When we create a vault, our max button will reduce 5% of our max available as a buffer to ensure transactions succeeds, this was implemented on launch because we had transactions failing at max mint

closes: #455 