### PR TITLE
Issue #466: RETH deposit bug

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -28,4 +28,4 @@ build-app:
     FROM +deps
     ARG ENVIRONMENT='local'
     ARG VERSION='latest'
-    RUN craco build
+    RUN yarn craco build

--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -25,6 +25,7 @@ import {
     StatsType,
 } from '~/hooks'
 import ConnectWalletStep from '~/components/ConnectWalletStep'
+import { useCollateralBalances } from '~/hooks/useCollateralBalances'
 
 const CreateVault = ({
     selectedItem,
@@ -85,12 +86,7 @@ const CreateVault = ({
         window.open(url, '_blank')
     }
 
-    const selectedTokenBalance = useMemo(() => {
-        if (selectedCollateralBalance) {
-            return formatNumber(selectedCollateralBalance, 2)
-        }
-        return formatNumber('0', 2)
-    }, [selectedCollateralBalance])
+    const selectedTokenBalance = useCollateralBalances(tokensData, tokensFetchedData, selectedItem)
 
     const collateralUnitPriceUSD = formatNumber(
         safeState.liquidationData?.collateralLiquidationData[selectedCollateral.symbol]?.currentPrice?.value || '0'

--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -108,9 +108,25 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
 
     const onMaxLeftInput = () => {
         if (isDeposit) {
-            onLeftInput(depositTokenBalance.toString())
+            const roundedDownBalance = ethers.utils.formatUnits(
+                ethers.utils.parseUnits(depositTokenBalance, selectedTokenDecimals),
+                selectedTokenDecimals
+            )
+            if (parseFloat(roundedDownBalance) > 1) {
+                onLeftInput(Math.floor(parseFloat(roundedDownBalance)).toString())
+            } else {
+                onLeftInput(depositTokenBalance.toString())
+            }
         } else {
-            onLeftInput(availableCollateral as string)
+            const roundedDownCollateral = ethers.utils.formatUnits(
+                ethers.utils.parseUnits(availableCollateral.toString(), selectedTokenDecimals),
+                selectedTokenDecimals
+            )
+            if (parseFloat(roundedDownCollateral) > 1) {
+                onLeftInput(Math.floor(parseFloat(roundedDownCollateral)).toString())
+            } else {
+                onLeftInput(availableCollateral.toString())
+            }
         }
     }
 

--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -108,17 +108,9 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
 
     const onMaxLeftInput = () => {
         if (isDeposit) {
-            const roundedDownBalance = ethers.utils.formatUnits(
-                ethers.utils.parseUnits(depositTokenBalance, selectedTokenDecimals),
-                selectedTokenDecimals
-            )
-            onLeftInput(Math.floor(parseFloat(roundedDownBalance)).toString())
+            onLeftInput(depositTokenBalance.toString())
         } else {
-            const roundedDownCollateral = ethers.utils.formatUnits(
-                ethers.utils.parseUnits(availableCollateral.toString(), selectedTokenDecimals),
-                selectedTokenDecimals
-            )
-            onLeftInput(Math.floor(parseFloat(roundedDownCollateral)).toString())
+            onLeftInput(availableCollateral as string)
         }
     }
 

--- a/src/hooks/useCollateralBalances.ts
+++ b/src/hooks/useCollateralBalances.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react'
+import { ethers } from 'ethers'
+import { formatNumber } from '~/utils/helper'
+import { TokenFetchData } from '@opendollar/sdk/lib/virtual/tokenData'
+import { TokenData } from '@opendollar/sdk/lib/contracts/addreses'
+
+/**
+ * Get the user's wallet balance for the selected collateral
+ * @param tokensData
+ * @param tokensFetchedData
+ * @param collateralName
+ */
+export const useCollateralBalances = (
+    tokensData: { [p: string]: TokenData },
+    tokensFetchedData: { [p: string]: TokenFetchData },
+    collateralName: string
+) => {
+    const collaterals = useMemo(() => {
+        return tokensData ? Object.values(tokensData).filter((token) => token.isCollateral) : []
+    }, [tokensData])
+
+    const formattedCollateralBalances = useMemo(() => {
+        return collaterals.reduce((acc, collateral) => {
+            const balance = tokensFetchedData[collateral.symbol]?.balanceE18 || '0'
+            const formattedBalance = ethers.utils.formatEther(balance)
+            return { ...acc, [collateral.symbol]: formattedBalance }
+        }, {} as { [symbol: string]: string })
+    }, [collaterals, tokensFetchedData])
+
+    const selectedCollateralBalance = formattedCollateralBalances[collateralName]
+
+    const selectedTokenBalance = useMemo(() => {
+        return selectedCollateralBalance ? formatNumber(selectedCollateralBalance, 2) : formatNumber('0', 2)
+    }, [selectedCollateralBalance])
+
+    return selectedTokenBalance
+}

--- a/src/hooks/useSafe.ts
+++ b/src/hooks/useSafe.ts
@@ -18,6 +18,7 @@ import {
     safeIsSafe,
     toFixedString,
 } from '~/utils/helper'
+import { useCollateralBalances } from '~/hooks/useCollateralBalances'
 
 export const LIQUIDATION_RATIO = 135 // percent
 export const ONE_DAY_WORTH_SF = ethers.utils.parseEther('0.00001')
@@ -45,7 +46,7 @@ export function useSafeInfo(type: SafeTypes = 'create') {
     const { t } = useTranslation()
     const {
         safeModel: { safeData, singleSafe, liquidationData },
-        connectWalletModel: { tokensFetchedData },
+        connectWalletModel: { tokensFetchedData, tokensData },
     } = useStoreState((state) => state)
 
     // parsed amounts of deposit/repay withdraw/borrow as in left input and right input, they get switched based on if its Deposit & Borrow or Repay & Withdraw
@@ -89,13 +90,16 @@ export function useSafeInfo(type: SafeTypes = 'create') {
     // returns liquidation price
     const liquidationPrice = useLiquidationPrice(totalCollateral, totalDebt, currentRedemptionPrice, liquidationCRatio)
 
+    const selectedTokenBalance = useCollateralBalances(tokensData, tokensFetchedData, collateralName)
+
+    const selectedTokenBalanceBN = BigNumber.from(toFixedString(selectedTokenBalance.toString(), 'WAD'))
+
     // returns available ETH (collateral)
     // singleSafe means already a deployed safe
     const availableCollateral = useMemo(() => {
         if (singleSafe) {
             if (type === 'deposit_borrow' && singleSafe.collateralName !== '') {
-                const value = ethers.utils.formatEther(tokensFetchedData[singleSafe.collateralName]?.balanceE18 ?? 0)
-                return formatNumber(value, 2)
+                return ethers.utils.formatEther(tokensFetchedData[singleSafe.collateralName]?.balanceE18 ?? 0)
             } else {
                 return singleSafe.collateral
             }
@@ -297,6 +301,9 @@ export function useSafeInfo(type: SafeTypes = 'create') {
     if (type === 'create') {
         if (leftInputBN.isZero()) {
             error = error ?? `Enter ${collateralName} Amount`
+        }
+        if (leftInputBN.gt(selectedTokenBalanceBN)) {
+            error = error ?? 'Insufficient balance'
         }
     }
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -242,7 +242,6 @@ export const safeIsSafe = (totalCollateral: string, totalDebt: string, safetyPri
     if (Number(totalCollateral) < 0) return false
     const totalCollateralBN = BigNumber.from(toFixedString(totalCollateral, 'WAD'))
     const safetyPriceBN = BigNumber.from(toFixedString(safetyPrice, 'RAY'))
-    console.log(totalDebtBN, 'totalDebtBN')
     return totalDebtBN.lte(totalCollateralBN.mul(safetyPriceBN).div(gebUtils.RAY))
 }
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -104,21 +104,25 @@ export const getRatePercentage = (value: string, digits = 4, returnRate = false)
     return formatNumber(String(ratePercentage * 100), digits)
 }
 
-export const toFixedString = (value: string, type?: keyof typeof floatsTypes): string => {
+export const toFixedString = (value: string, type: keyof typeof floatsTypes = 'WAD'): string => {
     try {
-        const n = Number(value)
-        const nOfDecimals = Number.isInteger(n) ? value.length : value.split('.')[1].length
-
-        if (type === 'WAD' || nOfDecimals === floatsTypes.WAD) {
-            return FixedNumber.fromString(value, 'fixed256x18').toHexString()
-        } else if (type === 'RAY' || (nOfDecimals > floatsTypes.WAD && nOfDecimals <= floatsTypes.RAY)) {
-            return FixedNumber.fromString(value, 'fixed256x27').toHexString()
-        } else if (type === 'RAD' || (nOfDecimals > floatsTypes.RAY && nOfDecimals <= floatsTypes.RAD)) {
-            return FixedNumber.fromString(value, 'fixed256x45').toHexString()
+        let scale
+        switch (type) {
+            case 'WAD':
+                scale = 'fixed256x18'
+                break
+            case 'RAY':
+                scale = 'fixed256x27'
+                break
+            case 'RAD':
+                scale = 'fixed256x45'
+                break
+            default:
+                scale = 'fixed256x18'
         }
-        return FixedNumber.fromString(value, 'fixed256x18').toHexString()
+        return FixedNumber.fromString(value, scale).toHexString()
     } catch (error) {
-        console.error('toFixedString error:', error)
+        console.debug('toFixedString error:', error)
         return '0'
     }
 }
@@ -238,6 +242,7 @@ export const safeIsSafe = (totalCollateral: string, totalDebt: string, safetyPri
     if (Number(totalCollateral) < 0) return false
     const totalCollateralBN = BigNumber.from(toFixedString(totalCollateral, 'WAD'))
     const safetyPriceBN = BigNumber.from(toFixedString(safetyPrice, 'RAY'))
+    console.log(totalDebtBN, 'totalDebtBN')
     return totalDebtBN.lte(totalCollateralBN.mul(safetyPriceBN).div(gebUtils.RAY))
 }
 


### PR DESCRIPTION
closes #466 

I found out in useSafe.ts the app has been rounding the collateral amount the user has to two decimals and this has been a thing since we forked the app. This has been forcing us to do a lot of weird rounding. These fixes might clean that up a bit 

## Description
- When creating RETH vault the deposit amount may be valid but client-side validation is triggered

This issue was caused by two things
1) On vault creation we don't have access to availableCollateral (which represent's the user's balance for a selected collateral). It's always 0 for some reason. I don't know when this changed but I now use the logic that we use to display the user's balance (Balance: X) instead to do this. I created a new hook called useCollateralBalances which correctly calculates the user's balance of a collateral selected and now we can access this balance (such as for RETH) during vault creation

2) isSafe in useSafe.ts calculates whether a vault modification would be safe or not. The problem is it was returning "false" when we wanted to deposit stuff to RETH because of differences in number types (totalDebtBN was 200143000000000000000 and we were comparing this to the amount the user wanted to deposit, which has less decimals but *should be* a bigger number). I had to modify the toFixedString function to properly format the numbers. toFixedString has been relying on the number of decimals that a number has to calculate it's type rather than using the type parameter which is hacky, so I changed this to rely on the type parameter instead). The reason it was working previously may or may not be because of the weird rounding we were doing to the collateral amount--we should watch this change closely to make sure it's ok because toFixedString is used in many places


- Added client-side validation for when a user tries to deposit more than what they have during vault creation (currently this validation only happened when modifying a vault for some reason, so a user might not know they don't have enough collateral to deposit unless we tell them)

- When pressing max and triggering onLeftInput sometimes the value is 0

We changed onMaxLeftInput to round down as part of #466. This presents problems when the collateral amount is less than 1 because rounding will cause the value to be 0. I added an if else to fix this

## Screenshots

When creating a vault the user's wallet balance is now correctly recognized

https://github.com/open-dollar/od-app/assets/47253537/ae6ee655-984a-492d-b362-4800bec29b5b

Users can deposit RETH

https://github.com/open-dollar/od-app/assets/47253537/b6b05358-0edb-45f7-ba43-f1830db572ca

Users can withdraw RETH

https://github.com/open-dollar/od-app/assets/47253537/b7f1ca49-a16f-49c8-8ffc-50e46e3ffe33

onMaxInput now works as expected 

https://github.com/open-dollar/od-app/assets/47253537/3f0ca014-69f3-4234-bc90-c613a96b7286





