### PR TITLE
Issue #462: Vault creation decimals

### DIFF
--- a/src/hooks/useSafe.ts
+++ b/src/hooks/useSafe.ts
@@ -135,7 +135,7 @@ export function useSafeInfo(type: SafeTypes = 'create') {
 
     const stabilityFeePercentage = useMemo(() => {
         return collateralLiquidationData
-            ? getRatePercentage(collateralLiquidationData.totalAnnualizedStabilityFee, 2)
+            ? getRatePercentage(collateralLiquidationData.totalAnnualizedStabilityFee, 3)
             : '-'
     }, [collateralLiquidationData])
 


### PR DESCRIPTION
Closes #462 

## Description
- Changed stability fee to have 2 decimals on the create vault page

## Screenshots

Before

<img width="1220" alt="Screenshot 2024-05-07 at 7 07 48 PM" src="https://github.com/open-dollar/od-app/assets/47253537/c6eba41d-1faf-464e-b9bb-20f5351dc73d">

After

<img width="1246" alt="after" src="https://github.com/open-dollar/od-app/assets/47253537/d79012a3-e42e-481a-a40e-84dcc91ec498">
