### PR TITLE
Issue #474. Header QA

### DIFF
--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -77,13 +77,13 @@ const Nav = styled.div`
 `
 
 const BtnStyle = css`
-    font-family: 'Barlow', sans-serif;
     color: black;
     transition: all 0.3s ease;
     padding: 10px 10px;
     width: 100%;
     padding-left: 20px;
     padding-right: 20px;
+    font-size: 14px;
     justify-content: center;
     font-weight: 700;
     height: 100%;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -344,7 +344,7 @@ const Navbar = () => {
                                         marginLeft: '20px',
                                         textAlign: 'center',
                                         justifyContent: 'center',
-                                        fontSize: 13,
+                                        fontSize: 14,
                                     }}
                                     onClick={handleWalletConnect}
                                 >
@@ -610,7 +610,10 @@ const ArrowWrapper = styled.div`
     margin-left: 8px;
 `
 
-const ClaimButton = styled(OdButton)``
+const ClaimButton = styled(OdButton)`
+    padding-left: 30px;
+    padding-right: 30px;
+`
 
 const DollarValue = styled(OdButton)`
     display: flex;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -555,6 +555,8 @@ const OdButton = styled.button`
     border-radius: 50px;
     transition: all 0.15s ease;
     box-sizing: border-box;
+    min-width: max-content;
+    width: auto;
 
     &:hover {
         transform: translateY(-0.5px);
@@ -614,13 +616,9 @@ const DollarValue = styled(OdButton)`
     align-items: center;
     justify-content: space-between;
     white-space: nowrap;
-    width: 150px;
 `
 
-const TotalValue = styled(OdButton)`
-    min-width: max-content;
-    width: auto;
-`
+const TotalValue = styled(OdButton)``
 
 const InfoPopUpHorizontalSeparator = styled.div`
     width: 100%;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -23,6 +23,7 @@ import discordIcon from '../assets/discord.svg'
 import walletIcon from '../assets/wallet-icon.svg'
 import od from '../assets/od-logo.svg'
 import odg from '../assets/odg.svg'
+import Loader from './Loader'
 
 const Navbar = () => {
     const theme = useTheme()
@@ -195,7 +196,7 @@ const Navbar = () => {
                         <Price>
                             <DollarValue ref={dollarRef} onClick={handleDollarClick}>
                                 <Icon src={getTokenLogo('OD')} width={22} height={22} />
-                                <span>{state.odPrice}</span>
+                                {state.odPrice ? <span>{state.odPrice}</span> : <Loader color="#0071E7" width="20px" />}
                                 <ArrowWrapper>
                                     <ArrowDown fill={isPopupVisible ? '#1499DA' : '#00587E'} />
                                 </ArrowWrapper>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -272,13 +272,13 @@ const Navbar = () => {
                         <BtnContainer>
                             {account ? (
                                 <RightPriceWrapper ref={odRef} style={{ marginLeft: 20 }}>
-                                    <DollarValue onClick={handleTokenClick}>
+                                    <TotalValue onClick={handleTokenClick}>
                                         <Icon src={walletIcon} width={22} height={22} />
                                         {odBalance + ' '} OD
                                         <ArrowWrapper>
                                             <ArrowDown fill={isTokenPopupVisible ? '#1499DA' : '#00587E'} />
                                         </ArrowWrapper>
-                                    </DollarValue>
+                                    </TotalValue>
                                     {isTokenPopupVisible && (
                                         <InfoPopup className="group">
                                             <InfoPopupContentWrapper>
@@ -615,6 +615,11 @@ const DollarValue = styled(OdButton)`
     justify-content: space-between;
     white-space: nowrap;
     width: 150px;
+`
+
+const TotalValue = styled(OdButton)`
+    min-width: max-content;
+    width: auto;
 `
 
 const InfoPopUpHorizontalSeparator = styled.div`

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -557,6 +557,7 @@ const OdButton = styled.button`
     box-sizing: border-box;
     min-width: max-content;
     width: auto;
+    height: 44px;
 
     &:hover {
         transform: translateY(-0.5px);

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -434,7 +434,7 @@ const Container = styled.div`
         top: 0 !important;
     }
 
-    $:after {
+    &:after {
         content: '';
         display: block;
         position: absolute;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -144,7 +144,7 @@ const Navbar = () => {
 
     const odBalance = useMemo(() => {
         const balances = connectWalletModel.tokensFetchedData
-        return formatDataNumber(balances.OD ? balances.OD.balanceE18.toString() : '0', 18, 2, false)
+        return formatDataNumber(balances.OD ? balances.OD.balanceE18.toString() : '0', 18, 2, false, true)
     }, [connectWalletModel.tokensFetchedData])
 
     useEffect(() => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -614,6 +614,7 @@ const DollarValue = styled(OdButton)`
     align-items: center;
     justify-content: space-between;
     white-space: nowrap;
+    width: 150px;
 `
 
 const InfoPopUpHorizontalSeparator = styled.div`

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -546,7 +546,7 @@ const OdButton = styled.button`
     color: ${(props) => props.theme.colors.accent};
     width: 15vw;
     max-width: 210px;
-    padding: 10px 12px 8px 12px;
+    padding: 10px 18px 8px;
     box-shadow: 0 4px ${(props) => props.theme.colors.primary};
     font-size: ${(props) => props.theme.font.xxSmall};
     font-weight: 700;


### PR DESCRIPTION
closes #474 

- Made text for header elements 14 px
- Increased paddings for text btns
- Btns width is flexible now
- Added property for OdBalance to make it compact. But need someone to check if that is right. I am confused about 18 decimals.

## Screenshots
<img width="1582" alt="Screenshot 2024-05-15 at 5 07 54 PM" src="https://github.com/open-dollar/od-app/assets/36742189/9c045a0e-c97a-4f7e-98db-751fa0af70cc">
