### PR TITLE
Issue #524: Bolts page cleanup

### DIFF
--- a/src/containers/Bolts/Affiliate.tsx
+++ b/src/containers/Bolts/Affiliate.tsx
@@ -145,12 +145,17 @@ const Container = styled.div`
 const Content = styled.div`
     display: flex;
     align-items: center;
+    column-gap: 10px;
 
     input {
         padding: 10px;
         border: 1px solid #ccc;
-        border-radius: 5px;
+        border-radius: 4px;
         width: 100%;
+    }
+    @media (max-width: 767px) {
+        flex-direction: column;
+        row-gap: 20px;
     }
 `
 
@@ -190,16 +195,12 @@ const ErrorMessage = styled.div`
 const BtnWrapper = styled.div`
     width: max-content;
     margin-right: auto;
-    margin-left: 10px;
     button {
-        height: 42px;
+        height: 49px;
         text-transform: uppercase;
         font-weight: 700;
         font-size: 18px;
-        padding: 17px 30px;
         display: flex;
-        justify-content: center;
-        align-items: center;
-        gap: 10px;
+        width: 280px;
     }
 `

--- a/src/containers/Bolts/QuestBlock.tsx
+++ b/src/containers/Bolts/QuestBlock.tsx
@@ -55,7 +55,7 @@ const BlockHeader = styled.div`
     ${({ theme }) => theme.mediaWidth.upToSmall`
         display: flex;
         flex-direction: column;
-        align-items: flex-end;
+        align-items: flex-start;
     `}
 `
 
@@ -79,7 +79,6 @@ const QuestTitle = styled.div`
     font-family: ${(props) => props.theme.family.headers};
     color: ${(props) => props.theme.colors.accent};
     font-weight: 700;
-
     margin-right: 22px;
 
     svg {
@@ -94,20 +93,13 @@ const QuestTitle = styled.div`
     ${({ theme }) => theme.mediaWidth.upToSmall`
     display: flex;
     flex-direction: column;
-    margin-left: 10px;
-
 `}
 `
 
 const Block = styled.div`
     display: flex;
     justify-content: start;
-
-    padding-left: 34px;
-    padding-top: 19px;
-    padding-bottom: 22px;
-    padding-right: 34px;
-
+    padding: 19px 34px 22px;
     ${({ theme }) => theme.mediaWidth.upToSmall`
            display: block;
            margin-top: 10px;
@@ -154,12 +146,12 @@ const Value = styled.div`
     display: flex;
     gap: 10px;
     min-height: 37px;
+    align-items: center;
     @media (max-width: 767px) {
         font-size: ${(props) => props.theme.font.small};
+        text-align: end;
+        max-width: 240px;
     }
-
-    display: flex;
-    align-items: end;
 
     &.status {
         color: #459d00;

--- a/src/containers/Bolts/index.tsx
+++ b/src/containers/Bolts/index.tsx
@@ -80,11 +80,11 @@ const Bolts = () => {
 }
 
 const Container = styled.div`
-    max-width: 1362px;
     margin: 80px auto;
     padding: 0 15px;
     @media (max-width: 767px) {
         margin: 50px auto;
+        padding: 0 10px;
     }
     color: ${(props) => props.theme.colors.accent};
 `
@@ -93,8 +93,10 @@ const Title = styled.h2`
     font-size: 34px;
     font-weight: 700;
     font-family: ${(props) => props.theme.family.headers};
-
     color: ${(props) => props.theme.colors.accent};
+    @media (max-width: 767px) {
+        text-align: center;
+    }
 `
 
 const SubHeader = styled.h3`
@@ -104,23 +106,23 @@ const SubHeader = styled.h3`
     font-weight: 700;
     color: ${(props) => props.theme.colors.tertiary};
     margin-bottom: 20px;
+    @media (max-width: 767px) {
+        font-size: 18px;
+        text-align: center;
+    }
 `
 
 const Text = styled.div`
     background-color: rgba(202, 234, 255, 0.3);
     backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0);
-    border-radius: 3px;
+    border-radius: 4px;
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-
     padding: 20px;
     font-size: ${(props) => props.theme.font.default};
-    border-radius: 3px;
-
     p {
         margin-bottom: 10px;
     }
-
     a {
         text-decoration: underline;
         color: ${(props) => props.theme.colors.tertiary};
@@ -130,26 +132,26 @@ const Text = styled.div`
 const BoltsDetails = styled.div`
     padding: 20px;
     margin-bottom: 30px;
-
     background-color: rgba(202, 234, 255, 0.3);
     backdrop-filter: blur(10px);
-
     border: 1px solid rgba(255, 255, 255, 0);
-    border-radius: 3px;
+    border-radius: 4px;
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-
     font-weight: 700;
     font-size: ${(props) => props.theme.font.default};
-
     display: flex;
     align-items: start;
     flex-direction: column;
-
     div {
         display: flex;
         justify-content: space-between;
     }
+    @media (max-width: 767px) {
+        padding: 15px;
+        font-size: ${(props) => props.theme.font.small};
+    }
 `
+
 const BoltsDetailsRow = styled.div`
     display: flex;
     justify-content: flex-start;
@@ -162,6 +164,7 @@ const SectionHeader = styled.h2`
     color: ${(props) => props.theme.colors.accent};
     margin-bottom: 20px;
 `
+
 const Section = styled.div``
 
 const BtnWrapper = styled.div`

--- a/src/containers/Bolts/quests.tsx
+++ b/src/containers/Bolts/quests.tsx
@@ -35,7 +35,7 @@ const ZealyLogo = () => (
 
 const GalxeLogo = () => (
     <LogoText>
-        <img alt="Galxe" src={galxeLogo} style={{ height: '17px' }} />
+        <img alt="Galxe" src={galxeLogo} style={{ height: '16px' }} />
     </LogoText>
 )
 
@@ -113,9 +113,9 @@ export const QUESTS = [
         title: (
             <TitleContainer>
                 <QuestTitle>Deposit Collateral</QuestTitle>
-                <img src={getTokenLogo('WSTETH')} alt={'WSTETH'} width={'50px'} />
-                <img src={getTokenLogo('RETH')} alt={'RETH'} width={'50px'} />
-                <img src={getTokenLogo('ARB')} alt={'ARB'} width={'50px'} />
+                <img src={getTokenLogo('WSTETH')} alt={'WSTETH'} width={'40px'} />
+                <img src={getTokenLogo('RETH')} alt={'RETH'} width={'40px'} />
+                <img src={getTokenLogo('ARB')} alt={'ARB'} width={'40px'} />
             </TitleContainer>
         ),
         button: <InternalLinkButton url="/vaults" />,
@@ -132,7 +132,7 @@ export const QUESTS = [
         title: (
             <TitleContainer>
                 <QuestTitle>Borrow OD</QuestTitle>
-                <img src={getTokenLogo('OD')} alt={'OD'} width={'50px'} />
+                <img src={getTokenLogo('OD')} alt={'OD'} width={'40px'} />
             </TitleContainer>
         ),
         button: <InternalLinkButton url="/vaults" />,
@@ -149,8 +149,8 @@ export const QUESTS = [
         title: (
             <TitleContainer>
                 <QuestTitle>Provide Liquidity ODG-ETH</QuestTitle>
-                <img src={getTokenLogo('ODG')} alt={'ODG'} width={'50px'} />
-                <img src={getTokenLogo('WETH')} alt={'WETH'} width={'50px'} />
+                <img src={getTokenLogo('ODG')} alt={'ODG'} width={'40px'} />
+                <img src={getTokenLogo('WETH')} alt={'WETH'} width={'40px'} />
             </TitleContainer>
         ),
         button: (
@@ -173,8 +173,8 @@ export const QUESTS = [
         title: (
             <TitleContainer>
                 <QuestTitle>Provide Liquidity OD-ETH</QuestTitle>
-                <img src={getTokenLogo('OD')} alt={'OD'} width={'50px'} />
-                <img src={getTokenLogo('WETH')} alt={'WETH'} width={'50px'} />
+                <img src={getTokenLogo('OD')} alt={'OD'} width={'40px'} />
+                <img src={getTokenLogo('WETH')} alt={'WETH'} width={'40px'} />
             </TitleContainer>
         ),
         button: (


### PR DESCRIPTION
closes #524 

## Description
- Fixed the referral link generation styling, now it's a column on mobile to avoid overflowing
- I made the "Bolts" headered centered on mobile because it looked a bit odd left aligned but I can change it back if you prefer
- Made sure logos and text are centered (including the galxe one), though it won't be perfect because they're not all easily resizable
- I'm going to make an issue to convert all our token icons to be react components so we can pass in dynamic widths and heights. Currently they're all hardcoded to different amounts and it causes them to resize weirdly on mobile but we need to change all of them to accept width and height props

## Screenshots

Invite a friend on mobile fixed

<img width="449" alt="invite a friend fixed" src="https://github.com/open-dollar/od-app/assets/47253537/12a9fa0e-745c-4a37-97ba-1bc57c302e60">

Desktop view

<img width="1045" alt="desktop" src="https://github.com/open-dollar/od-app/assets/47253537/a8df2f0d-4179-4ba7-b0e1-05fb31766c85">

Centered galxe as much as possible

<img width="646" alt="centered galxe" src="https://github.com/open-dollar/od-app/assets/47253537/5e7b2523-c464-4c47-a621-11381b8ff3d3">

Centered bolts text on mobile

<img width="449" alt="centered bolts" src="https://github.com/open-dollar/od-app/assets/47253537/f6d15c39-3f7d-4a0d-95b3-73c0b09da912">

This is the problem with all our token logos, they need to be refactored as react components so we can pass in exact widths and heights and then their containers won't shrink them like this on mobile

<img width="335" alt="Screenshot 2024-05-23 at 7 29 00 PM" src="https://github.com/open-dollar/od-app/assets/47253537/3896c512-afcb-4fbf-b79e-0edb072b41f9">

