### PR TITLE
Issue #564: Vault creation- small deposit warning

### DIFF
--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -321,7 +321,7 @@ const CreateVault = ({
                                                       }
                                                     : undefined
                                             }
-                                            label={`Balance: ${formatWithCommas(selectedTokenBalance, 2)} ${
+                                            label={`Balance: ${formatWithCommas(selectedTokenBalance, 4)} ${
                                                 selectedCollateral?.symbol
                                             }`}
                                             rightLabel={`~$${formatWithCommas(selectedTokenBalanceInUSD, 2)}`}
@@ -353,7 +353,7 @@ const CreateVault = ({
                                                     name: tokensData.OD.symbol,
                                                 }
                                             }
-                                            label={`Borrow OD: ${formatWithCommas(availableHai)} ${
+                                            label={`Borrow OD: ${formatWithCommas(availableHai, 4)} ${
                                                 tokensData.OD?.symbol
                                             }`}
                                             rightLabel={`~$${formatWithCommas(haiBalanceUSD)}`}
@@ -364,7 +364,16 @@ const CreateVault = ({
                                         />
                                     </Inputs>
                                     <Note data-test-id="debt_floor_note">
-                                        {` The minimum amount to mint per vault is ${debtFloor} OD`}
+                                        {`The minimum deposit size is ~$${
+                                            debtFloor *
+                                            Number(
+                                                safeState.liquidationData!.collateralLiquidationData[
+                                                    selectedCollateral?.symbol
+                                                ].liquidationCRatio
+                                            )
+                                        }.`}
+                                        <br />
+                                        {`The minimum amount to mint per vault is ${debtFloor} OD`}
                                     </Note>
                                 </Col>
                             ) : (

--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -345,22 +345,22 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
                                             <>
                                                 Borrow OD:{' '}
                                                 <Bold>
-                                                    &nbsp;{formatWithCommas(availableHai, 2)} {tokensData.OD.symbol}
+                                                    &nbsp;{formatWithCommas(availableHai, 4)} {tokensData.OD.symbol}
                                                 </Bold>
                                             </>
                                         ) : (
                                             <>
                                                 Balance:{' '}
                                                 <Bold>
-                                                    &nbsp;{formatWithCommas(haiBalance, 2)} {tokensData.OD.symbol}
+                                                    &nbsp;{formatWithCommas(haiBalance, 4)} {tokensData.OD.symbol}
                                                 </Bold>
                                             </>
                                         )
                                     }
                                     rightLabel={
                                         isDeposit
-                                            ? `~$${formatWithCommas(haiBalanceUSD, 2)}`
-                                            : `OD Owed: ${formatWithCommas(availableHai, 2)}`
+                                            ? `~$${formatWithCommas(haiBalanceUSD, 4)}`
+                                            : `OD Owed: ${formatWithCommas(availableHai, 4)}`
                                     }
                                     onChange={onRightInput}
                                     value={rightInput}

--- a/src/hooks/useCollateralBalances.ts
+++ b/src/hooks/useCollateralBalances.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
 import { ethers } from 'ethers'
-import { formatNumber } from '~/utils/helper'
 import { TokenFetchData } from '@opendollar/sdk/lib/virtual/tokenData'
 import { TokenData } from '@opendollar/sdk/lib/contracts/addreses'
 
@@ -30,7 +29,7 @@ export const useCollateralBalances = (
     const selectedCollateralBalance = formattedCollateralBalances[collateralName]
 
     const selectedTokenBalance = useMemo(() => {
-        return selectedCollateralBalance ? formatNumber(selectedCollateralBalance, 2) : formatNumber('0', 2)
+        return selectedCollateralBalance
     }, [selectedCollateralBalance])
 
     return selectedTokenBalance

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -311,7 +311,7 @@ export const checkUserHasBalance = async (
         provider
     )
     const balance = await tokenContract.balanceOf(userAddress)
-    return +ethers.utils.formatUnits(balance) <= +(amount || '0')
+    return +ethers.utils.formatUnits(balance) < +(amount || '0')
 }
 
 export const getUserBalance = async (tokens: any[], userAddress: string, rpcUrl: string) => {


### PR DESCRIPTION
closes #564 
closes #561 

- [X] Increase the number of decimals shown to 4 in the input, and in Overview during vault creation

note I only increase the token decimals to 4--the USD values are staying at 2 since it seems unnecessary to show 4 for these

- [X] Fix so decimal behavior is consistent across all vault creation/modificaiton forms 
- [X] Calculate for each collateral type:
```
200 * liqRatio = minimumDeposit
200 * 1.3 = $230 
```
- [X] Then show the result in the info message at the bottom
- [X] Fixed issue where "Insufficient funds. Move assets to Arbitrum using the Bridge" message shows up when the input is === to the user's token balance
- [X] selectedCollateralBalance was taking away decimals that we needed for the token balances--I changed the function to just return the unformatted value and we format it on the modify/create vault pages

Still unresolved is the max button issue--the amount of debt that a user can take out according to the app is too high (see discussion in front end channel)

## Screenshots

Max returns all 4 decimals of user's token balance

https://github.com/open-dollar/od-app/assets/47253537/f6ef1918-8971-4f67-876d-8eb932bb167b

Note the minimum deposit info in the CreateVault page

https://github.com/open-dollar/od-app/assets/472535

4 decimals modify vault page

<img width="1215" alt="4 decimals modify vault" src="https://github.com/open-dollar/od-app/assets/47253537/acf82c63-4430-44dd-9ddf-15bb09b2d39d">

4 decimals modify vault page (repay)

<img width="1260" alt="4 decimals repay" src="https://github.com/open-dollar/od-app/assets/47253537/6715131c-99e8-4507-9e0e-18a0af7b96ef">

4 decimals create vault page

<img width="1381" alt="4 ddecimals" src="https://github.com/open-dollar/od-app/assets/47253537/57cfce24-4e34-4b17-8d57-48f463312abd">




