### PR TITLE
Add buffer to max button in create/modify vault

### DIFF
--- a/src/hooks/useSafe.ts
+++ b/src/hooks/useSafe.ts
@@ -11,7 +11,7 @@ import {
     getCollateralRatio,
     getLiquidationPrice,
     getRatePercentage,
-    returnAvaiableDebt,
+    returnAvailableDebtWithBuffer,
     returnPercentAmount,
     returnTotalDebt,
     returnTotalValue,
@@ -124,14 +124,14 @@ export function useSafeInfo(type: SafeTypes = 'create') {
     const availableHai = useMemo(() => {
         if (!collateralLiquidationData) return '0.00'
         if (type === 'create') {
-            return returnAvaiableDebt(
+            return returnAvailableDebtWithBuffer(
                 collateralLiquidationData.currentPrice.safetyPrice,
                 collateralLiquidationData.accumulatedRate,
                 leftInput
             )
         } else if (type === 'deposit_borrow') {
             if (singleSafe) {
-                return returnAvaiableDebt(
+                return returnAvailableDebtWithBuffer(
                     collateralLiquidationData.currentPrice.safetyPrice,
                     collateralLiquidationData.accumulatedRate,
                     leftInput,

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -151,7 +151,7 @@ export const formatUserSafe = (
             const liquidationPenalty = collateralLiquidationData[token]?.liquidationPenalty
             const totalAnnualizedStabilityFee = collateralLiquidationData[token]?.totalAnnualizedStabilityFee
 
-            const availableDebt = returnAvaiableDebt(currentPrice?.safetyPrice, '0', s.collateral, s.debt)
+            const availableDebt = returnAvailableDebt(currentPrice?.safetyPrice, '0', s.collateral, s.debt)
 
             const totalDebt = returnTotalValue(returnTotalDebt(s.debt, accumulatedRate) as string, '0').toString()
 
@@ -288,7 +288,7 @@ export const returnTotalValue = (
     return formatNumber(gebUtils.wadToFixed(totalBN).toString()).toString()
 }
 
-export const returnAvaiableDebt = (
+export const returnAvailableDebt = (
     safetyPrice: string,
     accumulatedRate: string,
     currentCollatral = '0',
@@ -320,6 +320,27 @@ export const returnTotalDebt = (debt: string, accumulatedRate: string, beautify 
 
     if (!beautify) return totalDebtBN
     return gebUtils.wadToFixed(totalDebtBN).toString()
+}
+
+/**
+ * Returns the available debt with a 0.1% buffer to avoid exceeding the safety ratio
+ * @param safetyPrice
+ * @param accumulatedRate
+ * @param currentCollatral
+ * @param prevCollatral
+ * @param prevDebt
+ */
+export const returnAvailableDebtWithBuffer = (
+    safetyPrice: string,
+    accumulatedRate: string,
+    currentCollatral = '0',
+    prevCollatral = '0',
+    prevDebt = '0'
+) => {
+    const availableDebt = returnAvailableDebt(safetyPrice, accumulatedRate, currentCollatral, prevCollatral, prevDebt)
+    const availableDebtBN = BigNumber.from(toFixedString(availableDebt, 'WAD'))
+    const availableDebtWithBufferBN = availableDebtBN.mul(999).div(1000)
+    return formatNumber(gebUtils.wadToFixed(availableDebtWithBufferBN).toString()).toString()
 }
 
 export const returnTotalDebtPlusInterest = (


### PR DESCRIPTION
relates to #561 

- Adds a new function based off of returnAvailableDebt but with a 0.1% buffer to ensure the max OD taken out is not so high that the transaction fails.

## Screenshots

Create vault (note the collateral ratio, if we wanted to use a smaller buffer we could probably do so)

https://github.com/open-dollar/od-app/assets/47253537/8b93fcc0-2e9a-4b2f-9d8d-7985b4bcdf94

Modify vault

https://github.com/open-dollar/od-app/assets/47253537/fcae27b7-fc15-4c90-a44c-5ca23e6f0481




