### PR TITLE
Issue #508: Bug: View as another wallet 

### DIFF
--- a/src/components/VaultManager.tsx
+++ b/src/components/VaultManager.tsx
@@ -46,7 +46,11 @@ const VaultManager = () => {
                 return
             }
             popupsActions.setIsWaitingModalOpen(true)
-            history.push(`/${value}`)
+            if (window?.location) {
+                window.location.assign(`/${value}`)
+            } else {
+                history.push(`/${value}`)
+            }
             handleCancel()
             await timeout(3000)
             popupsActions.setIsWaitingModalOpen(false)

--- a/src/containers/Vaults/VaultDetails.tsx
+++ b/src/containers/Vaults/VaultDetails.tsx
@@ -31,14 +31,14 @@ const VaultDetails = ({ ...props }) => {
             return props.location.pathname.includes('deposit')
         }
         return false
-    }, [props])
+    }, [props.location])
 
     const isWithdraw = useMemo(() => {
         if (props.location) {
             return props.location.pathname.includes('withdraw')
         }
         return false
-    }, [props])
+    }, [props.location])
 
     const isOwner = useIsOwner(safeId)
 
@@ -52,6 +52,7 @@ const VaultDetails = ({ ...props }) => {
         if (safe && safeId && geb && liquidationData) {
             safeActions.setSingleSafe(safe)
             safeActions.setSafeData(DEFAULT_SAFE_STATE)
+            return
         }
 
         if (!safe && geb && safeId) {

--- a/src/model/safeModel.ts
+++ b/src/model/safeModel.ts
@@ -230,6 +230,9 @@ const safeModel: SafeModel = {
         state.list = payload
     }),
     setSingleSafe: action((state, payload) => {
+        if (!payload) {
+            return
+        }
         state.singleSafe = payload
     }),
     setOperation: action((state, payload) => {


### PR DESCRIPTION
closes #508 

## Description

There were two problems causing the user not to be able to see vaults while seeing the app as another user
1) We were using history.push to navigate to the vaults list for a different user, but history.push is internal routing for react so it was conserving the current wallet's address in the state and causing issues when trying to fetch the current user's vaults and the different user's vaults at the same time
2) In state management we were sometimes setting setSingleSafe to a null value, which doesn't make any sense and was causing the vault to be set to null when viewed as another user (I'm not sure exactly why it was coming as null once it was fetched more than once but we can prevent this anyway)

I added the following fixes:
- When window.location is available we use window.location.assign to move to the new route with the other user's address. This is kind of like doing a hard refresh while moving routes which prevents us from having issues with the current connected user's wallet from interfering with the new vaults we're trying to fetch
- Added an ```if (!payload)``` check to state management to make sure we don't set a fetched single vault as null. If a user connects their wallet while viewing the vault as another user (or if the wallet isn't connected at all) it will now properly fetch the vault 
- Some cleanup of VaultDetails like making sure the dependency arrays are specific enough and returning early in fetchSingleVaultData if the function should finish

## Screenshots

View app as certain user -> navigates to certain user's vault list -> we open the certain user's vault list with our wallet disconnected -> we connect our wallet and can still see the vault

https://github.com/open-dollar/od-app/assets/47253537/a1c90c80-6fd8-4e0a-a524-9bbf988b5aa8

