### PR TITLE
Issue #548: QA: Fuul SDK

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ Sentry.init({
     environment: process.env.NODE_ENV,
 })
 
-const network = process.env.REACT_APP_NETWORK_ID as string
+const network = process.env.REACT_APP_NETWORK_ID
 const fuulApiKey = process.env.REACT_APP_FUUL_API_KEY
 // Only initialize Fuul on Arbitrum One
 if (network === '42161' && fuulApiKey) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,13 +45,18 @@ Sentry.init({
     environment: process.env.NODE_ENV,
 })
 
-try {
-    Fuul.init({
-        apiKey: process.env.REACT_APP_FUUL_API_KEY!,
-    })
-    Fuul.sendPageview()
-} catch (e) {
-    console.log(e)
+const network = process.env.REACT_APP_NETWORK_ID as string
+const fuulApiKey = process.env.REACT_APP_FUUL_API_KEY
+// Only initialize Fuul on Arbitrum One
+if (network === '42161' && fuulApiKey) {
+    try {
+        Fuul.init({
+            apiKey: fuulApiKey,
+        })
+        Fuul.sendPageview()
+    } catch (e) {
+        console.log(e)
+    }
 }
 
 const App = () => {


### PR DESCRIPTION
closes #548 

## Description
- Only initializes Fuul if we're on Arbitrum One and the REACT_APP_FUUL_API_KEY was set