### PR TITLE
Issue #580: QA release: Bolts

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "react-feather": "^2.0.9",
         "react-helmet-async": "^1.0.7",
         "react-i18next": "^11.7.2",
+        "react-loading-skeleton": "^3.4.0",
         "react-number-format": "^5.2.2",
         "react-paginate": "^6.5.0",
         "react-router-dom": "^5.3.0",

--- a/src/components/AddressLink.tsx
+++ b/src/components/AddressLink.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import { ExternalLinkArrow } from '~/GlobalStyle'
-import { getEtherscanLink } from '~/utils'
-import { useAddress } from '~/hooks/useAddress'
+import { getEtherscanLink, returnWalletAddress } from '~/utils'
 
 export const Link = styled.a`
     ${ExternalLinkArrow}
@@ -15,7 +14,7 @@ interface AddressLinkProps {
 export const AddressLink = ({ chainId, address }: AddressLinkProps) => {
     return (
         <Link href={getEtherscanLink(chainId, address, 'address')} target="_blank">
-            {useAddress(address)}
+            {returnWalletAddress(address)}
         </Link>
     )
 }

--- a/src/components/AddressLink.tsx
+++ b/src/components/AddressLink.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { ExternalLinkArrow } from '~/GlobalStyle'
-import { getEtherscanLink, returnWalletAddress } from '~/utils'
+import { getEtherscanLink } from '~/utils'
+import { useAddress } from '~/hooks/useAddress'
 
 export const Link = styled.a`
     ${ExternalLinkArrow}
@@ -14,7 +15,7 @@ interface AddressLinkProps {
 export const AddressLink = ({ chainId, address }: AddressLinkProps) => {
     return (
         <Link href={getEtherscanLink(chainId, address, 'address')} target="_blank">
-            {returnWalletAddress(address)}
+            {useAddress(address, 0, true)}
         </Link>
     )
 }

--- a/src/components/Bolts/AddressCell.tsx
+++ b/src/components/Bolts/AddressCell.tsx
@@ -1,0 +1,68 @@
+import React, { useMemo } from 'react'
+import { useAddress } from '~/hooks/useAddress'
+import { returnWalletAddress } from '~/utils'
+import Skeleton from 'react-loading-skeleton'
+import { LeaderboardUser } from '~/model/boltsModel'
+import styled from 'styled-components'
+
+interface AddressCellProps {
+    address: string
+    userFuulDataAddress: string
+    data: LeaderboardUser[]
+}
+
+const AddressCell: React.FC<AddressCellProps> = ({ address, userFuulDataAddress, data }) => {
+    const userInTop10 = useMemo(() => data.find((user) => user.rank <= 10 && user.address === address), [data, address])
+    // Skip ENS check for users not in the top 10
+    const resolvedAddress = useAddress(address, 0, !userInTop10)
+
+    return (
+        <Address>
+            {userFuulDataAddress === address && (
+                <Badge
+                    style={{
+                        backgroundColor: '#e2f1ff',
+                        color: '#1a74ec',
+                        padding: '2px 8px',
+                        borderRadius: '4px',
+                        marginRight: '8px',
+                        fontWeight: 700,
+                        fontSize: '12px',
+                    }}
+                >
+                    YOU
+                </Badge>
+            )}
+            {typeof resolvedAddress === 'string' && resolvedAddress.startsWith('0x')
+                ? returnWalletAddress(address, 2)
+                : resolvedAddress || <Skeleton width={100} />}
+        </Address>
+    )
+}
+
+export default React.memo(AddressCell, (prevProps, nextProps) => {
+    return (
+        prevProps.address === nextProps.address &&
+        prevProps.userFuulDataAddress === nextProps.userFuulDataAddress &&
+        prevProps.data === nextProps.data
+    )
+})
+
+const Address = styled.span`
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 700;
+    font-size: ${(props: any) => props.theme.font.xSmall};
+    line-height: 21.79px;
+    letter-spacing: 0.05em;
+`
+
+const Badge = styled.span`
+    background-color: #e2f1ff;
+    color: #1a74ec;
+    padding: 2px 8px;
+    border-radius: 4px;
+    margin-right: 8px;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 700;
+    font-size: 12px;
+`

--- a/src/containers/Bolts/Leaderboard.tsx
+++ b/src/containers/Bolts/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import './leaderboard.css'
+import React, { useState, useEffect } from 'react'
 import {
     createColumnHelper,
     flexRender,
@@ -9,8 +9,9 @@ import {
     SortingState,
 } from '@tanstack/react-table'
 import styled from 'styled-components'
-import React, { useState, useEffect } from 'react'
 import { ArrowDown, ArrowUp } from 'react-feather'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
 import { returnWalletAddress } from '~/utils'
 import leaderboardLeadersBadge from '~/assets/leaderboard-leaders-badge.svg'
 import leaderboardPillars from '~/assets/leaderboard-pillars.svg'
@@ -141,33 +142,47 @@ const Table = ({ data, userFuulData }) => {
                     ))}
                 </thead>
                 <tbody>
-                    {table.getRowModel().rows.map((row, rowIndex) => (
-                        <tr
-                            key={row.id}
-                            style={
-                                // @ts-ignore
-                                row.original.address === userFuulData.address
-                                    ? { backgroundColor: '#8DB2FF99' }
-                                    : { backgroundColor: '#1A74EC' }
-                            }
-                        >
-                            {row.getVisibleCells().map((cell, index) => {
-                                let tdStyle: any = {}
-                                if (index === 2)
-                                    tdStyle = { textAlign: 'right', paddingRight: '20px', color: '#eeeeee' }
-                                else tdStyle = { paddingTop: '10px', color: '#eeeeee' }
-                                if (index === 0) tdStyle.paddingBottom = '10px'
-                                // @ts-ignore
-                                if (row?.original.address === userFuulData.address) tdStyle.color = '#1A74EC'
+                    {isTableReady
+                        ? table.getRowModel().rows.map((row, rowIndex) => (
+                              <tr
+                                  key={row.id}
+                                  style={
+                                      // @ts-ignore
+                                      row.original.address === userFuulData.address
+                                          ? { backgroundColor: '#8DB2FF99' }
+                                          : { backgroundColor: '#1A74EC' }
+                                  }
+                              >
+                                  {row.getVisibleCells().map((cell, index) => {
+                                      let tdStyle: any = {}
+                                      if (index === 2)
+                                          tdStyle = { textAlign: 'right', paddingRight: '20px', color: '#eeeeee' }
+                                      else tdStyle = { paddingTop: '10px', color: '#eeeeee' }
+                                      if (index === 0) tdStyle.paddingBottom = '10px'
+                                      // @ts-ignore
+                                      if (row?.original.address === userFuulData.address) tdStyle.color = '#1A74EC'
 
-                                return (
-                                    <td key={cell.id} style={tdStyle}>
-                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                    </td>
-                                )
-                            })}
-                        </tr>
-                    ))}
+                                      return (
+                                          <td key={cell.id} style={tdStyle}>
+                                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                          </td>
+                                      )
+                                  })}
+                              </tr>
+                          ))
+                        : new Array(10).fill(0).map((_, index) => (
+                              <tr key={index} style={{ backgroundColor: '#1A74EC' }}>
+                                  <td style={{ paddingTop: '10px', paddingBottom: '10px', color: '#eeeeee' }}>
+                                      <Skeleton height={20} width={50} />
+                                  </td>
+                                  <td style={{ paddingTop: '10px', paddingBottom: '10px', color: '#eeeeee' }}>
+                                      <Skeleton height={20} width={150} />
+                                  </td>
+                                  <td style={{ textAlign: 'right', paddingRight: '20px', color: '#eeeeee' }}>
+                                      <Skeleton height={20} width={80} />
+                                  </td>
+                              </tr>
+                          ))}
                 </tbody>
             </TableWrapper>
         </TableContainer>
@@ -247,6 +262,7 @@ const SortableHeader = styled.div`
 
 const TableWrapper = styled.table`
     width: 100%;
+    min-width: 100%;
     border-collapse: collapse;
     background-color: rgba(255, 255, 255, 0);
     backdrop-filter: blur(10px);
@@ -259,6 +275,7 @@ const TableContainer = styled.div`
     overflow: visible;
     position: relative;
     margin-bottom: 20px;
+    min-height: 550px;
     th,
     td {
         padding: 8px 0 8px 0;

--- a/src/containers/Bolts/index.tsx
+++ b/src/containers/Bolts/index.tsx
@@ -14,14 +14,11 @@ const Bolts = () => {
     const userFuulData = useStoreState((state) => state.boltsModel.userFuulData)
     const leaderboardData = useStoreState((state) => state.boltsModel.leaderboardData)
     const boltsEarnedData = useStoreState((state) => state.boltsModel.boltsEarnedData)
-    const hasFetched = useStoreState((state) => state.boltsModel.hasFetched)
     const fetchData = useStoreActions((actions) => actions.boltsModel.fetchData)
 
     useEffect(() => {
-        if (!hasFetched) {
-            fetchData({ account } as { account: string | null })
-        }
-    }, [account, hasFetched, fetchData])
+        fetchData({ account } as { account: string | null })
+    }, [account, fetchData])
 
     return (
         <Container>

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -10,8 +10,13 @@ const rpcProvider = new JsonRpcProvider(RPC_URL_ETHEREUM, 1)
  * Return the wallet address or ENS name if applicable
  * @param walletAddress
  * @param startingIndex
+ * @param skipEnsCheck
  */
-export function useAddress(walletAddress: string | undefined, startingIndex: number = 0) {
+export function useAddress(
+    walletAddress: string | undefined,
+    startingIndex: number = 0,
+    skipEnsCheck: boolean = false
+) {
     const { provider } = useWeb3React()
     const [address, setAddress] = useState<string | undefined>('')
     const ensCache = useStoreState((state) => state.boltsModel.ensCache)
@@ -22,7 +27,12 @@ export function useAddress(walletAddress: string | undefined, startingIndex: num
 
         const fetchData = async () => {
             if (walletAddress) {
-                if (ensCache[walletAddress]) {
+                if (skipEnsCheck) {
+                    const displayName = `${walletAddress.slice(startingIndex, 4 + 2)}...${walletAddress.slice(-4)}`
+                    if (isMounted) {
+                        setAddress(displayName)
+                    }
+                } else if (ensCache[walletAddress]) {
                     setAddress(ensCache[walletAddress])
                 } else {
                     try {
@@ -49,7 +59,7 @@ export function useAddress(walletAddress: string | undefined, startingIndex: num
         return () => {
             isMounted = false
         }
-    }, [provider, walletAddress, startingIndex, ensCache, setEnsCache])
+    }, [provider, walletAddress, startingIndex, skipEnsCheck, ensCache, setEnsCache])
 
     return address
 }

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { RPC_URL_ETHEREUM } from '~/chains'
+import { useStoreActions, useStoreState } from '~/store'
+
+const rpcProvider = new JsonRpcProvider(RPC_URL_ETHEREUM, 1)
 
 /**
  * Return the wallet address or ENS name if applicable
@@ -11,24 +14,31 @@ import { RPC_URL_ETHEREUM } from '~/chains'
 export function useAddress(walletAddress: string | undefined, startingIndex: number = 0) {
     const { provider } = useWeb3React()
     const [address, setAddress] = useState<string | undefined>('')
-
-    const rpcProvider = new JsonRpcProvider(RPC_URL_ETHEREUM, 1)
+    const ensCache = useStoreState((state) => state.boltsModel.ensCache)
+    const setEnsCache = useStoreActions((actions) => actions.boltsModel.setEnsCache)
 
     useEffect(() => {
         let isMounted = true
 
         const fetchData = async () => {
             if (walletAddress) {
-                try {
-                    const ensName = await rpcProvider.lookupAddress(walletAddress)
-                    if (isMounted) {
-                        setAddress(
+                if (ensCache[walletAddress]) {
+                    setAddress(ensCache[walletAddress])
+                } else {
+                    try {
+                        const ensName = await rpcProvider.lookupAddress(walletAddress)
+                        const displayName =
                             ensName || `${walletAddress.slice(startingIndex, 4 + 2)}...${walletAddress.slice(-4)}`
-                        )
-                    }
-                } catch (error) {
-                    if (isMounted) {
-                        setAddress(`${walletAddress.slice(startingIndex, 4 + 2)}...${walletAddress.slice(-4)}`)
+                        if (isMounted) {
+                            setAddress(displayName)
+                            setEnsCache({ address: walletAddress, ens: displayName })
+                        }
+                    } catch (error) {
+                        const displayName = `${walletAddress.slice(startingIndex, 4 + 2)}...${walletAddress.slice(-4)}`
+                        if (isMounted) {
+                            setAddress(displayName)
+                            setEnsCache({ address: walletAddress, ens: displayName })
+                        }
                     }
                 }
             }
@@ -39,8 +49,7 @@ export function useAddress(walletAddress: string | undefined, startingIndex: num
         return () => {
             isMounted = false
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [provider, walletAddress, startingIndex])
+    }, [provider, walletAddress, startingIndex, ensCache, setEnsCache])
 
     return address
 }

--- a/src/model/boltsModel.ts
+++ b/src/model/boltsModel.ts
@@ -1,0 +1,120 @@
+import { action, Action, thunk, Thunk } from 'easy-peasy'
+import { BoltsEarnedData } from '~/containers/Bolts/quests'
+
+type Conversion = {
+    is_referrer: boolean
+    conversion_id: number
+    conversion_name: string
+    total_amount: string
+}
+
+type LeaderboardUser = {
+    rank: number
+    address: string
+    points: number
+    ens?: string
+}
+
+export interface BoltsModel {
+    userFuulData: {
+        rank: string
+        points: string
+    }
+    setUserFuulData: Action<BoltsModel, { rank: string; points: string }>
+
+    leaderboardData: LeaderboardUser[]
+    setLeaderboardData: Action<BoltsModel, LeaderboardUser[]>
+
+    boltsEarnedData: BoltsEarnedData
+    setBoltsEarnedData: Action<BoltsModel, BoltsEarnedData>
+
+    hasFetched: boolean
+    setHasFetched: Action<BoltsModel, boolean>
+
+    ensCache: { [address: string]: string }
+    setEnsCache: Action<BoltsModel, { address: string; ens: string }>
+
+    fetchData: Thunk<BoltsModel, { account: string | null }, any, BoltsModel>
+}
+
+const boltsModel: BoltsModel = {
+    userFuulData: {
+        rank: '',
+        points: '',
+    },
+    setUserFuulData: action((state, payload) => {
+        state.userFuulData = payload
+    }),
+
+    leaderboardData: [],
+    setLeaderboardData: action((state, payload) => {
+        state.leaderboardData = payload
+    }),
+
+    boltsEarnedData: {},
+    setBoltsEarnedData: action((state, payload) => {
+        state.boltsEarnedData = payload
+    }),
+
+    hasFetched: false,
+    setHasFetched: action((state, payload) => {
+        state.hasFetched = payload
+    }),
+
+    ensCache: {},
+    setEnsCache: action((state, { address, ens }) => {
+        state.ensCache[address] = ens
+    }),
+
+    fetchData: thunk(async (actions, { account }, { getState }) => {
+        try {
+            const BOT_DOMAIN = 'https://bot.opendollar.com'
+            const BOT_API = `${BOT_DOMAIN}/api/bolts`
+            const response = account ? await fetch(`${BOT_API}?address=${account}`) : await fetch(BOT_API)
+            const result = await response.json()
+            if (result.success) {
+                const users = result.data.fuul.leaderboard.users
+                const state = getState()
+
+                // Populate ENS cache for leaderboard users
+                users.forEach((user: LeaderboardUser) => {
+                    const ens = state.ensCache[user.address] || null
+                    if (ens) {
+                        user.ens = ens
+                    }
+                })
+
+                actions.setLeaderboardData(users)
+
+                if (account) {
+                    actions.setUserFuulData(result.data.fuul.user)
+
+                    const boltsEarned: BoltsEarnedData = {}
+                    const { data } = result
+                    let combinedBorrowBolts = 0
+                    let combinedDepositBolts = 0
+                    data.fuul.user.conversions.forEach((conversion: Conversion) => {
+                        if ([1, 2].includes(conversion.conversion_id))
+                            combinedBorrowBolts += parseInt(conversion.total_amount)
+                        else if ([3, 4].includes(conversion.conversion_id))
+                            combinedDepositBolts += parseInt(conversion.total_amount)
+                        else boltsEarned[conversion.conversion_id] = parseInt(conversion.total_amount).toLocaleString()
+                    })
+                    boltsEarned[1] = combinedBorrowBolts.toLocaleString()
+                    boltsEarned[3] = combinedDepositBolts.toLocaleString()
+
+                    boltsEarned['OgNFT'] = data.OgNFT ? 'Yes' : 'No'
+                    boltsEarned['OgNFV'] = data.OgNFV ? 'Yes' : 'No'
+                    boltsEarned['GenesisNFT'] = data.GenesisNFT ? 'Yes' : 'No'
+
+                    actions.setBoltsEarnedData(boltsEarned)
+                }
+            }
+            actions.setHasFetched(true)
+        } catch (err) {
+            console.error('Error fetching leaderboard data:', err)
+        }
+    }),
+}
+
+export default boltsModel

--- a/src/model/boltsModel.ts
+++ b/src/model/boltsModel.ts
@@ -8,7 +8,7 @@ type Conversion = {
     total_amount: string
 }
 
-type LeaderboardUser = {
+export type LeaderboardUser = {
     rank: number
     address: string
     points: number
@@ -68,6 +68,7 @@ const boltsModel: BoltsModel = {
 
     fetchData: thunk(async (actions, { account }, { getState }) => {
         try {
+            console.log(account, 'account in fetchData')
             const BOT_DOMAIN = 'https://bot.opendollar.com'
             const BOT_API = `${BOT_DOMAIN}/api/bolts`
             const response = account ? await fetch(`${BOT_API}?address=${account}`) : await fetch(BOT_API)

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -9,6 +9,7 @@ import bridgeModel, { BridgeModel } from './bridgeModel'
 import nitroPoolsModel, { NitroPoolsModel } from './nitroPoolsModel'
 import analyticsModel, { AnalyticsModel } from './analyticsModel'
 import poolDataModel, { PoolDataModel } from '~/model/poolDataModel'
+import boltsModel, { BoltsModel } from './boltsModel'
 
 export interface StoreModel {
     settingsModel: SettingsModel
@@ -22,6 +23,7 @@ export interface StoreModel {
     nitroPoolsModel: NitroPoolsModel
     analyticsModel: AnalyticsModel
     poolDataModel: PoolDataModel
+    boltsModel: BoltsModel
 }
 
 const model: StoreModel = {
@@ -36,6 +38,7 @@ const model: StoreModel = {
     nitroPoolsModel,
     analyticsModel,
     poolDataModel,
+    boltsModel,
 }
 
 export default model

--- a/yarn.lock
+++ b/yarn.lock
@@ -15060,6 +15060,7 @@ __metadata:
     react-feather: ^2.0.9
     react-helmet-async: ^1.0.7
     react-i18next: ^11.7.2
+    react-loading-skeleton: ^3.4.0
     react-number-format: ^5.2.2
     react-paginate: ^6.5.0
     react-router-dom: ^5.3.0
@@ -17014,6 +17015,15 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
+  languageName: node
+  linkType: hard
+
+"react-loading-skeleton@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "react-loading-skeleton@npm:3.4.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: dca2c60d38abd57e658ff5abb02cf62c08b51e09e4c83e107a1fec3ad58d6f0068846b4149ee452d472e35c831b31a00e8cdbdb066dd35c8b47b803fbad1f834
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #580 

- [X] Bolts page reloads on every page switch

Fixed by creating boltsModel.ts and extracting the bolts info into our state management

- [X] ENS names should only be fetched for first 10 addresses

Fixed by creating an AddressCell component, creating a skipEnsFlag on useAddress (for addresses not in top 10) and memoizing AddressCell

- [X] Web3 object is being instantiated for each address, which makes lots of redundant rpc calls. It should be instantiated once

Fixed by moving declaration outside of hook

- [X] Leaderboard should be shown with react-loading-skeleton for each row. Page height should not change from loading-> complete states

Added react-loading-skeleton

- Refactored useAddress to cache addresses in our state management for address it has already looked up

- Added skipEns flag to AddressLink.tsx because this is only being used to look up contract addresses so no need to waste RPC calls on looking up their ENS

## Screenshots

Loading skeleton

https://github.com/open-dollar/od-app/assets/47253537/8ace5a96-7e48-4c03-b454-93a534a5ed92

Switching tabs = very few network calls, most info cached

https://github.com/open-dollar/od-app/assets/47253537/54d1b16a-780b-41bf-a157-98e7766ec8cf



