### PR TITLE
Issue #589: QA: create vault 

### DIFF
--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -111,7 +111,7 @@ const CreateVault = ({
     //const maxHaiWithBuffer = Math.trunc(+availableHai - (+availableHai * 5) / 100)
     const onMaxLeftInput = () => onLeftInput(selectedTokenBalance.toString())
     //available hai - 5% of available hai, this is a buffer to prevent bugs.
-    const onMaxRightInput = () => onRightInput(haiBalanceUSD.toString())
+    const onMaxRightInput = () => onRightInput(availableHai.toString())
 
     const onClearAll = useCallback(() => {
         clearAll()


### PR DESCRIPTION
closes #589 

## Description
- Fixed the bug where right input not erased if there's already text in the field

we need to use the availableHai variable to represent the max of the right input. This is because after triggering onMaxRightInput the rightInput variable is always undefined, which was causing the right input to not be set to anything (it doesn't change). availableHai is the correct up-to-date amount given a left input

## Screenshots

Some examples

https://github.com/open-dollar/od-app/assets/47253537/d01be642-f90f-4a20-afc8-d6c2ef8c4d08

Some more examples

https://github.com/open-dollar/od-app/assets/47253537/8c6a6f78-0ece-4d0a-b1fe-2685a027bae0

