### PR TITLE
Fix vault details not rendering when user has multiple vaults

### DIFF
--- a/src/model/safeModel.ts
+++ b/src/model/safeModel.ts
@@ -274,9 +274,6 @@ const safeModel: SafeModel = {
         state.list = payload
     }),
     setSingleSafe: action((state, payload) => {
-        if (!payload) {
-            return
-        }
         state.singleSafe = payload
     }),
     setOperation: action((state, payload) => {


### PR DESCRIPTION
## Description
- I found PR #573 is breaking the vault list--when a user has multiple vaults and they click into one then when they go back and click into another the vault details won't refresh. I reverted that one line change in that PR

- This reintroduces the problem of when a user is viewing a vault as another user and they connect their wallet then the vault will disappear, which I'll have to find a new solution for

## Screenshot

Multiple vaults can be viewed and refreshed appropriately

https://github.com/open-dollar/od-app/assets/47253537/11285f2b-7ab0-48b6-839b-c8c2cc6ddb90

