### PR TITLE
Issue #593:   Matomo e-commerce integration

### DIFF
--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -170,15 +170,15 @@ const CreateVault = ({
             const signer = provider.getSigner(account)
             try {
                 connectWalletActions.setIsStepLoading(true)
-                const depositAmount = collateralUnitPriceUSD ? Number(collateralUnitPriceUSD) : 0
-                const borrowAmount = haiBalanceUSD ? Number(haiBalanceUSD) : 0
+                const depositAmountUSD = collateralUnitPriceUSD ? Number(collateralUnitPriceUSD) : 0
+                const borrowAmountUSD = haiBalanceUSD ? Number(haiBalanceUSD) : 0
                 await safeActions.depositAndBorrow({
                     safeData: safeState.safeData,
                     signer,
                     geb,
                     account,
-                    depositAmount,
-                    borrowAmount,
+                    depositAmountUSD,
+                    borrowAmountUSD,
                 })
                 history.push('/vaults')
                 safeActions.setIsSuccessfulTx(true)

--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -170,11 +170,15 @@ const CreateVault = ({
             const signer = provider.getSigner(account)
             try {
                 connectWalletActions.setIsStepLoading(true)
+                const depositAmount = collateralUnitPriceUSD ? Number(collateralUnitPriceUSD) : 0
+                const borrowAmount = haiBalanceUSD ? Number(haiBalanceUSD) : 0
                 await safeActions.depositAndBorrow({
                     safeData: safeState.safeData,
                     signer,
                     geb,
                     account,
+                    depositAmount,
+                    borrowAmount,
                 })
                 history.push('/vaults')
                 safeActions.setIsSuccessfulTx(true)

--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -208,16 +208,22 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
             try {
                 connectWalletActions.setIsStepLoading(true)
                 if (safeState.singleSafe && isDeposit) {
+                    const depositAmount = collateralInUSD ? Number(collateralInUSD) : 0
+                    const borrowAmount = haiBalanceUSD ? Number(haiBalanceUSD) : 0
                     await safeActions.depositAndBorrow({
                         safeData: safeState.safeData,
                         signer,
                         safeId: safeState.singleSafe.id,
                         geb,
                         account,
+                        depositAmount,
+                        borrowAmount,
                     })
                 }
 
                 if (safeState.singleSafe && !isDeposit) {
+                    const withdrawAmount = collateralInUSD ? Number(collateralInUSD) : 0
+                    const repayAmount = haiBalanceUSD ? Number(haiBalanceUSD) : 0
                     await safeActions.repayAndWithdraw({
                         safeData: {
                             ...safeState.safeData,
@@ -227,6 +233,8 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
                         safeId: safeState.singleSafe.id,
                         geb,
                         account,
+                        withdrawAmount,
+                        repayAmount,
                     })
                 }
 

--- a/src/containers/Vaults/ModifyVault.tsx
+++ b/src/containers/Vaults/ModifyVault.tsx
@@ -208,22 +208,22 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
             try {
                 connectWalletActions.setIsStepLoading(true)
                 if (safeState.singleSafe && isDeposit) {
-                    const depositAmount = collateralInUSD ? Number(collateralInUSD) : 0
-                    const borrowAmount = haiBalanceUSD ? Number(haiBalanceUSD) : 0
+                    const depositAmountUSD = collateralInUSD ? Number(collateralInUSD) : 0
+                    const borrowAmountUSD = haiBalanceUSD ? Number(haiBalanceUSD) : 0
                     await safeActions.depositAndBorrow({
                         safeData: safeState.safeData,
                         signer,
                         safeId: safeState.singleSafe.id,
                         geb,
                         account,
-                        depositAmount,
-                        borrowAmount,
+                        depositAmountUSD,
+                        borrowAmountUSD,
                     })
                 }
 
                 if (safeState.singleSafe && !isDeposit) {
-                    const withdrawAmount = collateralInUSD ? Number(collateralInUSD) : 0
-                    const repayAmount = haiBalanceUSD ? Number(haiBalanceUSD) : 0
+                    const withdrawAmountUSD = collateralInUSD ? Number(collateralInUSD) : 0
+                    const repayAmountUSD = haiBalanceUSD ? Number(haiBalanceUSD) : 0
                     await safeActions.repayAndWithdraw({
                         safeData: {
                             ...safeState.safeData,
@@ -233,8 +233,8 @@ const ModifyVault = ({ isDeposit, isOwner, vaultId }: { isDeposit: boolean; isOw
                         safeId: safeState.singleSafe.id,
                         geb,
                         account,
-                        withdrawAmount,
-                        repayAmount,
+                        withdrawAmountUSD,
+                        repayAmountUSD,
                     })
                 }
 

--- a/src/model/safeModel.ts
+++ b/src/model/safeModel.ts
@@ -35,13 +35,17 @@ export interface SafeModel {
     uniSwapPool: ISafeData
     depositAndBorrow: Thunk<
         SafeModel,
-        ISafePayload & { safeId?: string } & { geb: Geb } & { account: string },
+        ISafePayload & { safeId?: string } & { geb: Geb } & { account: string } & { depositAmount: number } & {
+            borrowAmount?: number
+        },
         any,
         StoreModel
     >
     repayAndWithdraw: Thunk<
         SafeModel,
-        ISafePayload & { safeId: string } & { geb: Geb } & { account: string },
+        ISafePayload & { safeId: string } & { geb: Geb } & { account: string } & { withdrawAmount: number } & {
+            repayAmount?: number
+        },
         any,
         StoreModel
     >
@@ -122,21 +126,32 @@ const safeModel: SafeModel = {
             await txResponse.wait().then((receipt) => {
                 if (receipt && receipt.status === 1 && window?._paq) {
                     if (payload.safeData.leftInput !== '0') {
+                        window._paq.push(['trackEvent', 'Vault', 'Deposit', payload.account])
                         window._paq.push([
-                            'trackEvent',
-                            'Vault',
-                            'Deposit',
-                            payload.account,
-                            payload.safeData.leftInput,
+                            'addEcommerceItem',
+                            payload.safeData.collateral + '_Deposited', // (required) SKU: Product unique identifier
+                            payload.safeData.collateral + '_Deposited', // (optional) Product name
+                            'Collateral_Deposited', // (optional) Product category
+                        ])
+                        window._paq.push([
+                            'trackEcommerceOrder',
+                            (Math.random() * (2 - 1) + 1).toString(), // (required) unique order ID between 1 and 2
+                            payload.depositAmount,
                         ])
                     }
+
                     if (payload.safeData.rightInput !== '0') {
+                        window._paq.push(['trackEvent', 'Vault', 'Borrow', payload.account])
                         window._paq.push([
-                            'trackEvent',
-                            'Vault',
-                            'Borrow',
-                            payload.account,
-                            payload.safeData.rightInput,
+                            'addEcommerceItem',
+                            'OD_Borrowed', // (required) SKU: Product unique identifier
+                            'OD_Borrowed', // (optional) Product name
+                            'Debt_Borrowed', // (optional) Product category
+                        ])
+                        window._paq.push([
+                            'trackEcommerceOrder',
+                            (Math.random() * (2 - 1) + 1).toString(), // (required) unique order ID between 1 and 2
+                            payload.depositAmount,
                         ])
                     }
                 }
@@ -172,15 +187,31 @@ const safeModel: SafeModel = {
             await txResponse.wait().then((receipt) => {
                 if (receipt && receipt.status === 1 && window?._paq) {
                     if (payload.safeData.rightInput !== '0') {
-                        window._paq.push(['trackEvent', 'Vault', 'Repay', payload.account, payload.safeData.rightInput])
+                        window._paq.push(['trackEvent', 'Vault', 'Repay', payload.account])
+                        window._paq.push([
+                            'addEcommerceItem',
+                            'OD_Repaid', // (required) SKU: Product unique identifier
+                            'OD_Repaid', // (optional) Product name
+                            'Debt_Repaid', // (optional) Product category
+                        ])
+                        window._paq.push([
+                            'trackEcommerceOrder',
+                            (Math.random() * (2 - 1) + 1).toString(), // (required) unique order ID between 1 and 2
+                            payload.repayAmount,
+                        ])
                     }
                     if (payload.safeData.leftInput !== '0') {
+                        window._paq.push(['trackEvent', 'Vault', 'Withdraw', payload.account])
                         window._paq.push([
-                            'trackEvent',
-                            'Vault',
-                            'Withdraw',
-                            payload.account,
-                            payload.safeData.leftInput,
+                            'addEcommerceItem',
+                            payload.safeData.collateral + '_Withdrawn', // (required) SKU: Product unique identifier
+                            payload.safeData.collateral + '_Withdrawn', // (optional) Product name
+                            'Collateral_Withdrawn', // (optional) Product category
+                        ])
+                        window._paq.push([
+                            'trackEcommerceOrder',
+                            (Math.random() * (2 - 1) + 1).toString(), // (required) unique order ID between 1 and 2
+                            payload.withdrawAmount,
                         ])
                     }
                 }

--- a/src/model/safeModel.ts
+++ b/src/model/safeModel.ts
@@ -35,16 +35,16 @@ export interface SafeModel {
     uniSwapPool: ISafeData
     depositAndBorrow: Thunk<
         SafeModel,
-        ISafePayload & { safeId?: string } & { geb: Geb } & { account: string } & { depositAmount: number } & {
-            borrowAmount?: number
+        ISafePayload & { safeId?: string } & { geb: Geb } & { account: string } & { depositAmountUSD: number } & {
+            borrowAmountUSD?: number
         },
         any,
         StoreModel
     >
     repayAndWithdraw: Thunk<
         SafeModel,
-        ISafePayload & { safeId: string } & { geb: Geb } & { account: string } & { withdrawAmount: number } & {
-            repayAmount?: number
+        ISafePayload & { safeId: string } & { geb: Geb } & { account: string } & { withdrawAmountUSD: number } & {
+            repayAmountUSD?: number
         },
         any,
         StoreModel
@@ -136,7 +136,7 @@ const safeModel: SafeModel = {
                         window._paq.push([
                             'trackEcommerceOrder',
                             (Math.random() * (2 - 1) + 1).toString(), // (required) unique order ID between 1 and 2
-                            payload.depositAmount,
+                            payload.depositAmountUSD,
                         ])
                     }
 
@@ -151,7 +151,7 @@ const safeModel: SafeModel = {
                         window._paq.push([
                             'trackEcommerceOrder',
                             (Math.random() * (2 - 1) + 1).toString(), // (required) unique order ID between 1 and 2
-                            payload.depositAmount,
+                            payload.depositAmountUSD,
                         ])
                     }
                 }
@@ -197,7 +197,7 @@ const safeModel: SafeModel = {
                         window._paq.push([
                             'trackEcommerceOrder',
                             (Math.random() * (2 - 1) + 1).toString(), // (required) unique order ID between 1 and 2
-                            payload.repayAmount,
+                            payload.repayAmountUSD,
                         ])
                     }
                     if (payload.safeData.leftInput !== '0') {
@@ -211,7 +211,7 @@ const safeModel: SafeModel = {
                         window._paq.push([
                             'trackEcommerceOrder',
                             (Math.random() * (2 - 1) + 1).toString(), // (required) unique order ID between 1 and 2
-                            payload.withdrawAmount,
+                            payload.withdrawAmountUSD,
                         ])
                     }
                 }


### PR DESCRIPTION
closes #593 

I had to make a couple changes from the original plan to have it conform with Matomo's requirements
- Matomo requires that we do addEcommerceItem before doing trackEcommerceOrder so I created 4 different addEcommerceItem products: "OD_Repaid", "OD_Borrowed", "COLLATERAL_Deposited", and "COLLATERAL_Withdrawn" where "COLLATERAL" is a variable representing the collateral name

- I added trackEcommerceOrder events for deposit, borrow, withdraw, repay 

The order ID has to be unique so we can't do the plan of doing total number of vaults + 1 or the existing vault ID because this would lead to nonsensical data if someone does more than one thing per vault

- I removed the deposit info I was adding to trackEvent because it's useless info to track the input value rather than the USD value of the input, and now the ecommerce integration will do that for us