### PR TITLE
Issue #595: Viewing vault as another user 

### DIFF
--- a/src/containers/Vaults/VaultDetails.tsx
+++ b/src/containers/Vaults/VaultDetails.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -47,8 +47,18 @@ const VaultDetails = ({ ...props }) => {
     const safes = safeState.list
     const safe = safes.find((safe) => safe.id === safeId)
 
+    // Ref to track the number of fetchSingleVaultData calls
+    const fetchCallCount = useRef(0)
+
     // Fetches vault data of a vault not owned by the user
     const fetchSingleVaultData = async () => {
+        fetchCallCount.current += 1
+
+        if (fetchCallCount.current > 10) {
+            props.history.push('/vaults')
+            return
+        }
+
         if (safe && safeId && geb && liquidationData) {
             safeActions.setSingleSafe(safe)
             safeActions.setSafeData(DEFAULT_SAFE_STATE)


### PR DESCRIPTION
closes #595 

## Description
- Added logic to catch an infinite loop of fetchSingleVaultData() (which occurs when the user connects their wallet while viewing a vault as another user) and if it occurs it'll push the user back to the /vaults route, which refreshes the vault list and shows their own vaults, leaving the mode of viewing the app as another user

The issue occurs when a user views the app as another wallet -> automatically is navigated to /vaults -> user navigates to a vault -> user connects their wallet

I tried to make changes in the useEffect in VaultDetails to prevent an infinite loop, but it seems like when a user connects their wallet the app's data becomes polluted (maybe a mismatch of liquidation/safe data for the safe the user is viewing vs. what was fetched as another user?) and it triggers an infinite loop. Some other things I've tried are memoizing the data in VaultDetails, adding debouncing to see if it's a timing issue (it's not), removing the ```safeActions.setSingleSafe(null)``` cleanup function (which helps trigger the infinite loop) but removing this causes the caching issue we had before (where a user with 1+ vaults will only ever see the data for the first vault they click)

## Screenshots

In this example I'm connected as another wallet -> I click into a vault -> I connect my wallet -> the app pushes me back to /vaults where the data is refreshed and I can see my own vault

https://github.com/open-dollar/od-app/assets/47253537/9699e091-f406-4178-83a8-f62bc157eec7


