### PR TITLE
Stats page - total system surplus

### DIFF
--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -68,6 +68,7 @@ const Analytics = () => {
         globalDebt,
         globalDebtCeiling,
         globalDebtUtilization,
+        surplusInTreasury,
         marketPrice,
         redemptionPrice,
         totalLiquidity,
@@ -162,6 +163,13 @@ const Analytics = () => {
 
     const circulation = { title: 'circulation', value: erc20Supply, description: 'Circulating supply of OD stablecoin' }
 
+    const surplusInTreasuryData: DataCardProps = {
+        title: 'Surplus in Treasury',
+        value: surplusInTreasury,
+        description:
+            "Total HAI accrued by the system's stability fees. It's stored in the Stability Fee Treasury accountance",
+    }
+
     const liquidityUniswap = {
         title: 'OD/ETH Liquidity in Camelot',
         value: totalLiquidity,
@@ -244,6 +252,7 @@ const Analytics = () => {
         // totalFeesEarned,
         globalDebtUtilizationData,
         globalDebtData,
+        surplusInTreasuryData,
     ]
 
     const pricesData: DataCardProps[] = [
@@ -267,7 +276,7 @@ const Analytics = () => {
                 0,
                 true
             ).toString()
-
+            console.log("analytics data", analyticsData)
             const colRows = Object.fromEntries(
                 Object.entries(analyticsData?.tokenAnalyticsData).map(([key, value]) => {
                     const lockedAmountInUsd = multiplyWad(
@@ -324,7 +333,7 @@ const Analytics = () => {
                     analyticsData.globalDebt,
                     analyticsData.globalDebtCeiling
                 ),
-                surplusInTreasury: formatDataNumber(analyticsData.surplusInTreasury, 18, 0, true),
+                surplusInTreasury: `${formatDataNumber(analyticsData.surplusInTreasury, 18, 0)} OD`,
                 marketPrice: formatDataNumber(analyticsData.marketPrice, 18, 3, true, undefined, 4),
                 redemptionPrice: formatDataNumber(analyticsData.redemptionPrice, 18, 3, true, undefined, 4),
                 totalLiquidity: formattedLiquidity,

--- a/src/utils/formatDataNumber.ts
+++ b/src/utils/formatDataNumber.ts
@@ -31,7 +31,7 @@ export function formatDataNumber(
     return new Intl.NumberFormat('en-US', {
         minimumFractionDigits: minimumDecimals,
         maximumFractionDigits:
-            minimumDecimals >= formatDecimal ? Math.min(minimumDecimals, formatDecimal) + 1 : formatDecimal,
+            (minimumDecimals >= formatDecimal && formatDecimal !== 0) ? Math.min(minimumDecimals, formatDecimal) + 1 : formatDecimal,
         notation: compact ? 'compact' : 'standard',
         style: currency ? 'currency' : 'decimal',
         currency: 'USD',


### PR DESCRIPTION
closes #585 

### Question
Why we add 1 if min decimals <= then format decimals? If we put format decimals, don't we want to be exact this number? 
I changed the logic so it doesn't work if format decimals === 0, but let me know if we should change it (hope it breaks nothing else)
#### Before
<img width="865" alt="Screenshot 2024-07-01 at 1 29 36 PM" src="https://github.com/open-dollar/od-app/assets/36742189/b8ebcb2c-987d-458e-831d-46544173042b">

#### After
<img width="1014" alt="Screenshot 2024-07-01 at 1 31 51 PM" src="https://github.com/open-dollar/od-app/assets/36742189/3a4f9957-589c-49ed-a100-088ddde34306">

### Screenshot
<img width="1284" alt="Screenshot 2024-07-01 at 1 40 24 PM" src="https://github.com/open-dollar/od-app/assets/36742189/dbeb6df7-d5a5-4c57-9fef-8722686b524f">


