### PR TITLE
Issue #607: Add global vault state 

### DIFF
--- a/src/model/globalSafeModel.ts
+++ b/src/model/globalSafeModel.ts
@@ -1,0 +1,39 @@
+import { action, Action, thunk, Thunk } from 'easy-peasy'
+import { StoreModel } from '~/model'
+import { fetchGlobalSafes } from '~/services/safes'
+import { timeout, ILiquidationData, ISafe, IFetchGlobalSafesPayload } from '~/utils'
+
+export interface GlobalSafeModel {
+    list: Array<ISafe>
+    liquidationData: ILiquidationData | null
+    fetchGlobalSafes: Thunk<GlobalSafeModel, IFetchGlobalSafesPayload, any, StoreModel>
+    setList: Action<GlobalSafeModel, Array<ISafe>>
+    setLiquidationData: Action<GlobalSafeModel, ILiquidationData>
+}
+
+const globalSafeModel: GlobalSafeModel = {
+    list: [],
+    liquidationData: null,
+    fetchGlobalSafes: thunk(async (actions, payload) => {
+        let fetched
+        try {
+            fetched = await fetchGlobalSafes(payload)
+        } catch (e) {
+            console.debug('Failed to fetch global safes', e)
+        }
+        if (fetched) {
+            actions.setList(fetched.globalSafes)
+            actions.setLiquidationData(fetched.liquidationData)
+            await timeout(200)
+            return fetched
+        }
+    }),
+    setList: action((state, payload) => {
+        state.list = payload
+    }),
+    setLiquidationData: action((state, payload) => {
+        state.liquidationData = payload
+    }),
+}
+
+export default globalSafeModel

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -2,6 +2,7 @@ import settingsModel, { SettingsModel } from './settingsModel'
 import popupsModel, { PopupsModel } from './popupsModel'
 import connectWalletModel, { ConnectWalletModel } from './connectWalletModel'
 import safeModel, { SafeModel } from './safeModel'
+import globalSafeModel, { GlobalSafeModel } from './globalSafeModel'
 import transactionsModel, { TransactionsModel } from './transactionsModel'
 import multicallModel, { MulticallModel } from './multicallModel'
 import auctionModel, { AuctionModel } from './auctionModel'
@@ -16,6 +17,7 @@ export interface StoreModel {
     popupsModel: PopupsModel
     connectWalletModel: ConnectWalletModel
     safeModel: SafeModel
+    globalSafeModel: GlobalSafeModel
     transactionsModel: TransactionsModel
     multicallModel: MulticallModel
     auctionModel: AuctionModel
@@ -31,6 +33,7 @@ const model: StoreModel = {
     popupsModel,
     connectWalletModel,
     safeModel,
+    globalSafeModel,
     transactionsModel,
     multicallModel,
     auctionModel,

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -127,6 +127,13 @@ export const toFixedString = (value: string, type: keyof typeof floatsTypes = 'W
     }
 }
 
+const getBytes32String = (collateralType: string, tokensData: { [key: string]: TokenData }): string | null => {
+    const token = Object.values(tokensData).find(
+        (token) => token.symbol === collateralType || token.bytes32String === collateralType
+    )
+    return token ? token.bytes32String : null
+}
+
 export const formatUserSafe = (
     safes: Array<any>,
     liquidationData: ILiquidationData,
@@ -141,17 +148,18 @@ export const formatUserSafe = (
     const { currentRedemptionPrice, currentRedemptionRate, collateralLiquidationData } = liquidationData
 
     return safes
-        .filter((s) => s.collateralType in collateralBytes32)
         .map((s) => {
-            const token = collateralBytes32[s.collateralType]
+            const bytes32String = getBytes32String(s.collateralType, tokensData)
+            if (!bytes32String || !(bytes32String in collateralBytes32)) return null
+
+            const token = collateralBytes32[bytes32String]
             const accumulatedRate = collateralLiquidationData[token]?.accumulatedRate
             const currentPrice = collateralLiquidationData[token]?.currentPrice
+            const availableDebt = returnAvailableDebt(currentPrice?.safetyPrice, '0', s.collateral, s.debt)
             const liquidationCRatio = collateralLiquidationData[token]?.liquidationCRatio
             const safetyCRatio = collateralLiquidationData[token]?.safetyCRatio
             const liquidationPenalty = collateralLiquidationData[token]?.liquidationPenalty
             const totalAnnualizedStabilityFee = collateralLiquidationData[token]?.totalAnnualizedStabilityFee
-
-            const availableDebt = returnAvailableDebt(currentPrice?.safetyPrice, '0', s.collateral, s.debt)
 
             const totalDebt = returnTotalValue(returnTotalDebt(s.debt, accumulatedRate) as string, '0').toString()
 
@@ -171,12 +179,13 @@ export const formatUserSafe = (
 
             return {
                 id: s.safeId,
+                ownerAddress: s.ownerAddress,
                 safeHandler: s.safeHandler,
                 date: s.createdAt,
                 riskState: ratioChecker(Number(collateralRatio), Number(liquidationCRatio), Number(safetyCRatio)),
                 collateral: s.collateral,
                 collateralType: s.collateralType,
-                collateralName: collateralBytes32[s.collateralType],
+                collateralName: collateralBytes32[bytes32String],
                 debt: s.debt,
                 totalDebt,
                 availableDebt,
@@ -192,6 +201,7 @@ export const formatUserSafe = (
                 currentRedemptionRate: currentRedemptionRate || '0',
             } as ISafe
         })
+        .filter((s): s is ISafe => s !== null)
         .sort((a, b) => Number(b.riskState) - Number(a.riskState) || Number(b.debt) - Number(a.debt))
 }
 

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -16,6 +16,10 @@ export interface DynamicObject {
     [key: string]: any
 }
 
+export interface IOwnerAddressesResponse {
+    ownerAddresses: string[]
+}
+
 interface IColors {
     primary: string
     secondary: string
@@ -362,6 +366,11 @@ export interface IFetchTokensDataPayload {
 
 export interface IFetchSafesPayload {
     address: string
+    geb: Geb
+    tokensData: { [key: string]: TokenData }
+}
+
+export interface IFetchGlobalSafesPayload {
     geb: Geb
     tokensData: { [key: string]: TokenData }
 }


### PR DESCRIPTION
closes #607 

## Description
- This properly populates a new globalStateModel object in our state management library with all the vault information for the 84 existing vaults
- I have it fetching the global vault state every 60 seconds just like the user vaults but maybe we want to change this
- I have it fetching the vault owners from the API because I assume it's more efficient than doing contract calls but this also means we should probably tweak the bot to allow us to call it with localhost without having to disable CORS
- I almost was able to fix the bug in #595 with this new object but I still need to tweak it some more



