### PR TITLE
Issue #612: matomo race conditions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -58,8 +58,8 @@
         <title>OD | App</title>
 
         <!-- Matomo -->
-        <script src="./tracking.js" defer></script>
-        <script src="https://usekeyp.matomo.cloud/matomo.js" async defer></script>
+        <script src="./tracking.js"></script>
+        <script src="https://usekeyp.matomo.cloud/matomo.js"></script>
         <!-- End Matomo Code -->
         <script type="text/javascript" src="https://kb.wowto.ai/widgets/M4cmuZpuJqb/widget.js" async defer></script>
     </head>


### PR DESCRIPTION
closes #612 

## Description
- I removed the async defer from the matomo JS scripts in index.html. In the deployment for this branch I don't see the error (after disabling ad block), but I also don't see the error in the dev deployment, only main