### PR TITLE
Address ENS loading skeleton

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -299,7 +299,9 @@ const Navbar = () => {
                                                             <IdenticonWrapper>
                                                                 <Identicon />
                                                             </IdenticonWrapper>
-                                                            <InfoPopUpText>{address || <Skeleton width={150} height={18}/>}</InfoPopUpText>
+                                                            <InfoPopUpText>
+                                                                {address || <Skeleton width={150} height={18} />}
+                                                            </InfoPopUpText>
                                                         </InnerBtn>
                                                     )}
                                                 </Button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,6 +24,7 @@ import TokenIcon from './TokenIcon'
 import walletIcon from '../assets/wallet-icon.svg'
 import DollarValueInner from './DollarValueInner'
 import { useAddress } from '~/hooks/useAddress'
+import Skeleton from 'react-loading-skeleton'
 
 const Navbar = () => {
     const theme = useTheme()
@@ -298,7 +299,7 @@ const Navbar = () => {
                                                             <IdenticonWrapper>
                                                                 <Identicon />
                                                             </IdenticonWrapper>
-                                                            <InfoPopUpText>{address}</InfoPopUpText>
+                                                            <InfoPopUpText>{address || <Skeleton width={150} height={18}/>}</InfoPopUpText>
                                                         </InnerBtn>
                                                     )}
                                                 </Button>

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -21,6 +21,7 @@ import WalletIcon from '~/assets/wallet-icon.svg'
 import DollarValueInner from './DollarValueInner'
 import parachuteIcon from '../assets/parachute-icon.svg'
 import { useAddress } from '~/hooks/useAddress'
+import Skeleton from 'react-loading-skeleton'
 
 const SideMenu = () => {
     const nodeRef = React.useRef(null)
@@ -47,7 +48,7 @@ const SideMenu = () => {
     } = useStoreState((state) => state)
     const poolData = usePoolData()
     const analyticsData = useAnalyticsData()
-    const address = useAddress(account)
+    let address = useAddress(account)
 
     const handleWalletConnect = () => popupsActions.setIsConnectorsWalletOpen(true)
 
@@ -135,7 +136,6 @@ const SideMenu = () => {
             console.log('Error adding ODG to the wallet:', error)
         }
     }
-
     useEffect(() => {
         if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return
         if (poolData && analyticsData) {
@@ -180,7 +180,6 @@ const SideMenu = () => {
     useEffect(() => {
         setIsOpen(popupsState.showSideMenu)
     }, [popupsState.showSideMenu])
-
     return isOpen ? (
         <CSSTransition
             in={isOpen}
@@ -209,7 +208,7 @@ const SideMenu = () => {
                                 >
                                     <ConnectedWalletIcon size={40} />
                                     <AccountData>
-                                        <Address>{address}</Address>
+                                        <Address>{address || <Skeleton width={115} />}</Address>
                                         <Balance>{`$ ${renderBalance()}`}</Balance>
                                     </AccountData>
                                 </Account>

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -269,8 +269,6 @@ const VaultStats = ({
                                         <Skeleton
                                             width={130}
                                             height={18}
-                                            baseColor={'#89B3FB'}
-                                            highlightColor="#2871FD"
                                         />
                                     )}
                                 </StatValue>

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { ExternalLink, Info } from 'react-feather'
@@ -20,6 +20,7 @@ import { Tooltip as ReactTooltip } from 'react-tooltip'
 import { generateSvg } from '@opendollar/svg-generator'
 import { useWeb3React } from '@web3-react/core'
 import { useAddress } from '~/hooks/useAddress'
+import Skeleton from 'react-loading-skeleton'
 
 const VaultStats = ({
     isModifying,
@@ -88,7 +89,7 @@ const VaultStats = ({
     )
 
     const svg = useMemo(() => generateSvg(statsForSVG), [statsForSVG])
-    const address = useAddress(singleSafe?.ownerAddress || account!)
+    let address = useAddress(singleSafe?.ownerAddress || account!)
 
     const returnRedRate = () => {
         const currentRedemptionRate = singleSafe ? getRatePercentage(singleSafe.currentRedemptionRate, 10) : '0'
@@ -253,10 +254,10 @@ const VaultStats = ({
                                     </InfoIcon>
                                 </StatHeader>
                                 <StatValue>
-                                    {chainId && (
+                                    {address ? (
                                         <AccountLink
                                             href={getEtherscanLink(
-                                                chainId,
+                                                chainId!,
                                                 singleSafe?.ownerAddress || account!,
                                                 'address'
                                             )}
@@ -264,6 +265,13 @@ const VaultStats = ({
                                         >
                                             {address} <ExternalLink />
                                         </AccountLink>
+                                    ) : (
+                                        <Skeleton
+                                            width={130}
+                                            height={18}
+                                            baseColor={'#89B3FB'}
+                                            highlightColor="#2871FD"
+                                        />
                                     )}
                                 </StatValue>
                             </StatSection>

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -266,10 +266,7 @@ const VaultStats = ({
                                             {address} <ExternalLink />
                                         </AccountLink>
                                     ) : (
-                                        <Skeleton
-                                            width={130}
-                                            height={18}
-                                        />
+                                        <Skeleton width={130} height={18} />
                                     )}
                                 </StatValue>
                             </StatSection>

--- a/src/containers/Earn/index.tsx
+++ b/src/containers/Earn/index.tsx
@@ -106,13 +106,7 @@ const Earn = () => {
                         ) => <PoolBlock {...pool} nitroPoolData={nitroPools[i]} key={`${pool.nitroPoolAddress}-pool`} />
                     )
                 ) : (
-                    <Skeleton
-                        height={185}
-                        count={3}
-                        baseColor={'#89B3FB'}
-                        highlightColor="#2871FD"
-                        style={{ marginBottom: '30px' }}
-                    />
+                    <Skeleton height={185} count={3} style={{ marginBottom: '30px' }} />
                 )}
             </Pools>
 


### PR DESCRIPTION
closes #616 
- added to wallet component in a navbar and sidemenu
- added to vault stats
- already exists in leaderboard 

## Questions
- Do we use primary color for all skeletons or somewhere we use grey?
- Do we want to use skeletons for balance as well?

### Vault stats grey
https://github.com/user-attachments/assets/16b5e8b7-bb28-4b14-b7ae-0029b5b84705
### Vault stats primary gradient
https://github.com/user-attachments/assets/5fd9fa16-ba3c-4a66-b88b-10dc1b8bb330

### Wallet component image
<img width="639" alt="Screenshot 2024-07-12 at 1 18 52 PM" src="https://github.com/user-attachments/assets/123aa4a0-07b8-43cf-8513-d50c61e2d0f3">

### Wallet component video

https://github.com/user-attachments/assets/5ebf0893-7aab-4e41-b142-429be0826909






