### PR TITLE
Issue #619: /explore continued

### DIFF
--- a/src/containers/Earn/EarnBlock.tsx
+++ b/src/containers/Earn/EarnBlock.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { formatWithCommas, getTokenLogo } from '~/utils'
 import { Tooltip as ReactTooltip } from 'react-tooltip'
 
 const Link = styled.a``

--- a/src/containers/Explore/ExploreTable.tsx
+++ b/src/containers/Explore/ExploreTable.tsx
@@ -12,6 +12,7 @@ import './index.css'
 import styled from 'styled-components'
 import Button from '~/components/Button'
 import { useState } from 'react'
+import { useHistory } from 'react-router-dom'
 
 type Vault = {
     id: string
@@ -36,94 +37,91 @@ const parseDebtAmount = (value: string): number => {
 }
 
 const columnHelper = createColumnHelper<Vault>()
-const columns: ColumnDef<Vault, any>[] = [
-    columnHelper.accessor('id', {
-        header: () => 'ID',
-        cell: (info) => info.getValue(),
-        sortingFn: 'alphanumeric',
-        enableSorting: true,
-    }),
-    columnHelper.accessor('image', {
-        header: () => '',
-        cell: (info) => {
-            const image = info.row.original.image
-            const vaultID = info.row.original.id
-            return image ? (
-                <SVGContainer key={vaultID}>
-                    <SvgWrapper key={vaultID} dangerouslySetInnerHTML={{ __html: image }}></SvgWrapper>
-                </SVGContainer>
-            ) : null
-        },
-        enableSorting: false,
-    }),
-    columnHelper.accessor('collateralAmount', {
-        header: () => 'Collateral Amount',
-        cell: (info) => info.getValue().toLocaleString(),
-        sortingFn: (rowA, rowB) => {
-            const a = rowA.getValue<number>('collateralAmount')
-            const b = rowB.getValue<number>('collateralAmount')
-            return a - b
-        },
-        filterFn: (row, columnId, filterValue) => {
-            const value = row.getValue<number>(columnId)
-            return value.toString().includes(filterValue)
-        },
-    }),
-    columnHelper.accessor('collateral', {
-        header: () => 'Collateral',
-        cell: (info) => info.getValue(),
-        sortingFn: 'alphanumeric',
-        enableSorting: true,
-    }),
-    columnHelper.accessor('debtAmount', {
-        header: () => 'Debt Amount',
-        cell: (info) => info.getValue(),
-        sortingFn: (rowA, rowB) => {
-            const a = parseDebtAmount(rowA.getValue<string>('debtAmount'))
-            const b = parseDebtAmount(rowB.getValue<string>('debtAmount'))
-            return a - b
-        },
-        filterFn: (row, columnId, filterValue) => {
-            const value = parseDebtAmount(row.getValue<string>(columnId))
-            return value.toString().includes(filterValue)
-        },
-    }),
-    columnHelper.accessor('riskStatus', {
-        header: () => 'Risk Status',
-        cell: (info) => info.getValue().toLocaleString(),
-        sortingFn: (rowA, rowB) => {
-            const a = riskStatusMapping[rowA.getValue<string>('riskStatus')] || 1
-            const b = riskStatusMapping[rowB.getValue<string>('riskStatus')] || 1
-            return a - b
-        },
-        filterFn: (row, columnId, filterValue) => {
-            const value = row.getValue<string>(columnId)
-            return value.includes(filterValue)
-        },
-    }),
-    columnHelper.accessor('actions', {
-        header: '',
-        cell: (info) => {
-            return (
-                <ButtonFloat>
-                    <Button
-                        secondary
-                        onClick={() =>
-                            window.location.assign(`https://app.opendollar.com/vaults/${info.row.original.id}`)
-                        }
-                    >
-                        View
-                    </Button>
-                </ButtonFloat>
-            )
-        },
-        enableSorting: false,
-    }),
-]
 
 const ExploreTable = ({ data }: { data: Vault[] }) => {
     const [sorting, setSorting] = useState<SortingState>([])
     const [globalFilter, setGlobalFilter] = useState<string>('')
+    const history = useHistory()
+
+    const columns: ColumnDef<Vault, any>[] = [
+        columnHelper.accessor('id', {
+            header: () => 'ID',
+            cell: (info) => info.getValue(),
+            sortingFn: 'alphanumeric',
+            enableSorting: true,
+        }),
+        columnHelper.accessor('image', {
+            header: () => '',
+            cell: (info) => {
+                const image = info.row.original.image
+                const vaultID = info.row.original.id
+                return image ? (
+                    <SVGContainer key={vaultID}>
+                        <SvgWrapper key={vaultID} dangerouslySetInnerHTML={{ __html: image }}></SvgWrapper>
+                    </SVGContainer>
+                ) : null
+            },
+            enableSorting: false,
+        }),
+        columnHelper.accessor('collateralAmount', {
+            header: () => 'Collateral Amount',
+            cell: (info) => info.getValue().toLocaleString(),
+            sortingFn: (rowA, rowB) => {
+                const a = rowA.getValue<number>('collateralAmount')
+                const b = rowB.getValue<number>('collateralAmount')
+                return a - b
+            },
+            filterFn: (row, columnId, filterValue) => {
+                const value = row.getValue<number>(columnId)
+                return value.toString().includes(filterValue)
+            },
+        }),
+        columnHelper.accessor('collateral', {
+            header: () => 'Collateral',
+            cell: (info) => info.getValue(),
+            sortingFn: 'alphanumeric',
+            enableSorting: true,
+        }),
+        columnHelper.accessor('debtAmount', {
+            header: () => 'Debt Amount',
+            cell: (info) => info.getValue(),
+            sortingFn: (rowA, rowB) => {
+                const a = parseDebtAmount(rowA.getValue<string>('debtAmount'))
+                const b = parseDebtAmount(rowB.getValue<string>('debtAmount'))
+                return a - b
+            },
+            filterFn: (row, columnId, filterValue) => {
+                const value = parseDebtAmount(row.getValue<string>(columnId))
+                return value.toString().includes(filterValue)
+            },
+        }),
+        columnHelper.accessor('riskStatus', {
+            header: () => 'Risk Status',
+            cell: (info) => info.getValue().toLocaleString(),
+            sortingFn: (rowA, rowB) => {
+                const a = riskStatusMapping[rowA.getValue<string>('riskStatus')] || 1
+                const b = riskStatusMapping[rowB.getValue<string>('riskStatus')] || 1
+                return a - b
+            },
+            filterFn: (row, columnId, filterValue) => {
+                const value = row.getValue<string>(columnId)
+                return value.includes(filterValue)
+            },
+        }),
+        columnHelper.accessor('actions', {
+            header: '',
+            cell: (info) => {
+                return (
+                    <ButtonFloat>
+                        <Button secondary onClick={() => history.push(`/vaults/${info.row.original.id}`)}>
+                            View
+                        </Button>
+                    </ButtonFloat>
+                )
+            },
+            enableSorting: false,
+        }),
+    ]
 
     const table = useReactTable({
         data: data,

--- a/src/containers/Vaults/VaultDetails.tsx
+++ b/src/containers/Vaults/VaultDetails.tsx
@@ -105,7 +105,7 @@ const VaultDetails = ({ ...props }) => {
             safeActions.setSingleSafe(null)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [safe, safeActions, geb, liquidationData, safeActions.setLiquidationData, account])
+    }, [safeId, geb])
 
     useEffect(() => {
         if (!account || !provider) return


### PR DESCRIPTION
closes #619 

## Description
- [X] Entire app re-loads when we click on the svg image or "View" button. This is not the expected behavior for internal links

I added history.push to do internal routing instead. It looks like a lot of code has changed but that's because I had to refactor the code to be able to call history.push properly (since useHistory is a hook we couldn't call it in our regular method that we had before)

The infinite loop was being caused by a bunch of dependencies in our VaultDetails.tsx component that we didn't need--we only need to re-render a vault's details when either we're viewing a new vault (vault id changes) or the user connects/disconnects their wallet (geb changes). The rest are not necessary

- [X] Fix improper rendered vaults svgs

Fixed in https://github.com/open-dollar/od-app/pull/639


## Screenshots

These screenshots don't have the new explore page design, it's just this routing change

View vault from /explore when wallet not connected

https://github.com/user-attachments/assets/3c5a1fcf-0fcb-4dbf-85a5-92f62e1948ed

View vault from /explore when wallet connected

https://github.com/user-attachments/assets/3cdebaf9-73cd-4aef-afcc-09d25852631b

(Existing behavior) View vault from homepage when wallet connected

https://github.com/user-attachments/assets/0a128a8e-3e3e-4138-9ae0-a427b2ea8063

(Existing behavior) View vault from homepage when wallet disconnected

https://github.com/user-attachments/assets/84370346-3830-478a-b341-de436b43314d




