### PR TITLE
Issue #642: Reconnect on refresh

### DIFF
--- a/src/components/CreateVaultStep.tsx
+++ b/src/components/CreateVaultStep.tsx
@@ -10,11 +10,11 @@ interface Props {
     btnText: string
     handleClick: () => void
     isDisabled: boolean
-    isLoading: boolean
+    isStepLoading: boolean
     id: string
 }
 
-const CreateVaultStep = ({ stepNumber, title, text, isDisabled, isLoading, btnText, handleClick }: Props) => {
+const CreateVaultStep = ({ stepNumber, title, text, isDisabled, isStepLoading, btnText, handleClick }: Props) => {
     const { t } = useTranslation()
     return (
         <ContentContainer stepNumber={stepNumber}>
@@ -27,8 +27,8 @@ const CreateVaultStep = ({ stepNumber, title, text, isDisabled, isLoading, btnTe
                 <Button
                     data-test-id="steps-btn"
                     id={stepNumber === 2 ? 'create-safe' : ''}
-                    disabled={isDisabled || isLoading}
-                    isLoading={isLoading}
+                    disabled={isDisabled || isStepLoading}
+                    isLoading={isStepLoading}
                     text={t(btnText)}
                     onClick={handleClick}
                     secondary

--- a/src/components/StepsContent.tsx
+++ b/src/components/StepsContent.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import Skeleton from 'react-loading-skeleton'
 import 'react-loading-skeleton/dist/skeleton.css'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Button from './Button'
 import closedVault from '../assets/closed-vault.webp'
 import wallet from '../assets/wallet.webp'
@@ -32,14 +32,27 @@ const StepsContent = ({ title, text, stepNumber, btnText, handleClick, isDisable
     const useReturnLottie = (step: number) => {
         const [loaded, setLoaded] = useState(false)
 
+        useEffect(() => {
+            // Fallback to load image
+            const timer = setTimeout(() => {
+                setLoaded(true)
+            }, 3000)
+
+            return () => clearTimeout(timer)
+        }, [step])
+
         const handleImageLoad = () => {
             setLoaded(true)
         }
 
         const imageSrc = [closedVault, wallet, vaultFacilitator, openedVault][step] || closedVault
 
+        useEffect(() => {
+            setLoaded(false)
+        }, [step])
+
         return (
-            <>
+            <div>
                 {!loaded && <Skeleton baseColor={'rgb(220 241 255)'} width="100%" height="330px" />}
                 <img
                     src={imageSrc}
@@ -50,7 +63,7 @@ const StepsContent = ({ title, text, stepNumber, btnText, handleClick, isDisable
                     onLoad={handleImageLoad}
                     style={{ display: loaded ? 'block' : 'none' }}
                 />
-            </>
+            </div>
         )
     }
 

--- a/src/components/StepsContent.tsx
+++ b/src/components/StepsContent.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import Skeleton from 'react-loading-skeleton'
 import 'react-loading-skeleton/dist/skeleton.css'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import Button from './Button'
 import closedVault from '../assets/closed-vault.webp'
 import wallet from '../assets/wallet.webp'
@@ -32,27 +32,14 @@ const StepsContent = ({ title, text, stepNumber, btnText, handleClick, isDisable
     const useReturnLottie = (step: number) => {
         const [loaded, setLoaded] = useState(false)
 
-        useEffect(() => {
-            // Fallback to load image
-            const timer = setTimeout(() => {
-                setLoaded(true)
-            }, 3000)
-
-            return () => clearTimeout(timer)
-        }, [step])
-
         const handleImageLoad = () => {
             setLoaded(true)
         }
 
         const imageSrc = [closedVault, wallet, vaultFacilitator, openedVault][step] || closedVault
 
-        useEffect(() => {
-            setLoaded(false)
-        }, [step])
-
         return (
-            <div>
+            <>
                 {!loaded && <Skeleton baseColor={'rgb(220 241 255)'} width="100%" height="330px" />}
                 <img
                     src={imageSrc}
@@ -63,7 +50,7 @@ const StepsContent = ({ title, text, stepNumber, btnText, handleClick, isDisable
                     onLoad={handleImageLoad}
                     style={{ display: loaded ? 'block' : 'none' }}
                 />
-            </div>
+            </>
         )
     }
 

--- a/src/components/connectorCards/WalletConnectV2Card.tsx
+++ b/src/components/connectorCards/WalletConnectV2Card.tsx
@@ -19,7 +19,6 @@ import { useEffect, useState } from 'react'
 import { MAINNET_CHAINS } from '../../chains'
 import { hooks, walletConnectV2 } from '../../connectors/walletConnectV2'
 import { Card } from './Card'
-import { useActiveWeb3React } from '~/hooks'
 import { useStoreActions } from '~/store'
 
 const CHAIN_IDS = Object.keys(MAINNET_CHAINS).map(Number)
@@ -38,7 +37,6 @@ export default function WalletConnectV2Card({ error, setError }: WalletConnectV2
     const isActive = useIsActive()
     const provider = useProvider()
     const { popupsModel: popupsActions } = useStoreActions((state) => state)
-    const { connector } = useActiveWeb3React()
 
     // attempt to connect eagerly on mount
     useEffect(() => {
@@ -47,7 +45,7 @@ export default function WalletConnectV2Card({ error, setError }: WalletConnectV2
             .then(() => userInitiatedConnection && popupsActions.setIsConnectorsWalletOpen(false))
             .catch(() => {})
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [connector])
+    }, [])
 
     // log URI when available
     useEffect(() => {

--- a/src/containers/Explore/ExploreTable.tsx
+++ b/src/containers/Explore/ExploreTable.tsx
@@ -12,7 +12,7 @@ import './index.css'
 import styled from 'styled-components'
 import Button from '~/components/Button'
 import { useState } from 'react'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 
 type Vault = {
     id: string
@@ -41,7 +41,7 @@ const columnHelper = createColumnHelper<Vault>()
 const ExploreTable = ({ data }: { data: Vault[] }) => {
     const [sorting, setSorting] = useState<SortingState>([])
     const [globalFilter, setGlobalFilter] = useState<string>('')
-    const history = useHistory()
+    const navigate = useNavigate()
 
     const columns: ColumnDef<Vault, any>[] = [
         columnHelper.accessor('id', {
@@ -113,7 +113,7 @@ const ExploreTable = ({ data }: { data: Vault[] }) => {
             cell: (info) => {
                 return (
                     <ButtonFloat>
-                        <Button secondary onClick={() => history.push(`/vaults/${info.row.original.id}`)}>
+                        <Button secondary onClick={() => navigate(`/vaults/${info.row.original.id}`)}>
                             View
                         </Button>
                     </ButtonFloat>

--- a/src/containers/Vaults/index.tsx
+++ b/src/containers/Vaults/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { useStoreState } from '~/store'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -8,6 +8,8 @@ import { COIN_TICKER } from '~/utils'
 import { useTranslation } from 'react-i18next'
 import Accounts from './Accounts'
 import Loader from '~/components/Loader'
+import useGeb from '~/hooks/useGeb'
+import { useWeb3React } from '@web3-react/core'
 
 interface OnBoardingProps {
     className?: string
@@ -17,14 +19,26 @@ const OnBoarding = ({ className }: OnBoardingProps) => {
     const navigate = useNavigate()
     const { t } = useTranslation()
 
-    const [loading] = useState(false)
+    const [loading, setLoading] = useState(true)
     const { address } = useParams<{ address: string }>()
     const { connectWalletModel: connectWalletState, safeModel: safeState } = useStoreState((state) => state)
     const { isWrongNetwork, isStepLoading } = connectWalletState
+    const geb = useGeb()
+    const { account } = useWeb3React()
 
     const handleCreateSafe = () => {
         navigate('/vaults/create')
     }
+
+    useEffect(() => {
+        if (geb && !account) {
+            setLoading(false)
+        } else if ((connectWalletState.tokensData && account) || geb) {
+            setTimeout(() => {
+                setLoading(false)
+            }, 1000)
+        }
+    }, [loading, geb, connectWalletState.tokensData, account])
 
     return (
         <Container id="app-page" className={className}>
@@ -40,10 +54,10 @@ const OnBoarding = ({ className }: OnBoardingProps) => {
                             btnText={'create_safe'}
                             handleClick={handleCreateSafe}
                             isDisabled={isWrongNetwork}
-                            isLoading={isStepLoading}
+                            isStepLoading={isStepLoading}
                         />
                     </>
-                ) : loading ? (
+                ) : loading || isStepLoading ? (
                     <LoaderWrapper>
                         <Loader width="200px" color="#1A74EC" />
                     </LoaderWrapper>

--- a/src/containers/Vaults/index.tsx
+++ b/src/containers/Vaults/index.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useState } from 'react'
-import { isAddress } from '@ethersproject/address'
+import { useState } from 'react'
 import styled from 'styled-components'
-import { useStoreState, useStoreActions } from '~/store'
-import { useActiveWeb3React } from '~/hooks'
+import { useStoreState } from '~/store'
 import { useNavigate, useParams } from 'react-router-dom'
-import useGeb from '~/hooks/useGeb'
 import CreateVaultStep from '~/components/CreateVaultStep'
 import VaultList from './VaultList'
 import { COIN_TICKER } from '~/utils'
@@ -18,41 +15,12 @@ interface OnBoardingProps {
 
 const OnBoarding = ({ className }: OnBoardingProps) => {
     const navigate = useNavigate()
-    const { account, provider, chainId } = useActiveWeb3React()
-    const geb = useGeb()
     const { t } = useTranslation()
 
-    const [loading, setLoading] = useState(false)
+    const [loading] = useState(false)
     const { address } = useParams<{ address: string }>()
     const { connectWalletModel: connectWalletState, safeModel: safeState } = useStoreState((state) => state)
-    const { safeModel: safeActions } = useStoreActions((state) => state)
     const { isWrongNetwork, isStepLoading } = connectWalletState
-
-    useEffect(() => {
-        if (chainId !== 421614 && chainId !== 42161 && chainId !== 10) return
-        if ((!account && !address) || (address && !isAddress(address.toLowerCase())) || !provider || isWrongNetwork)
-            return
-
-        const fetchSafes = async () => {
-            setLoading(true)
-            try {
-                await safeActions.fetchUserSafes({
-                    address: address || (account as string),
-                    geb,
-                    tokensData: connectWalletState.tokensData,
-                })
-                setLoading(false)
-            } catch (error) {
-                console.debug('Error fetching safes:', error)
-                setLoading(false)
-            }
-        }
-
-        if (geb && connectWalletState.tokensData) fetchSafes()
-
-        const interval = setInterval(fetchSafes, 3000)
-        return () => clearInterval(interval)
-    }, [account, address, isWrongNetwork, connectWalletState.tokensData, geb, provider, safeActions, chainId])
 
     const handleCreateSafe = () => {
         navigate('/vaults/create')

--- a/src/hooks/useActiveWeb3React.ts
+++ b/src/hooks/useActiveWeb3React.ts
@@ -31,18 +31,17 @@ export function useEagerConnect() {
     const { isActive, connector } = useWeb3React() // specifically using useWeb3ReactCore because of what this hook does
 
     useEffect(() => {
-        if (!window?.ethereum)
-            if (!isActive) {
-                injected.isAuthorized().then((isAuthorized) => {
-                    if (isAuthorized) {
+        if (!isActive) {
+            injected.isAuthorized().then((isAuthorized) => {
+                if (isAuthorized) {
+                    connector.activate(injected, undefined, true)
+                } else {
+                    if (isMobile && window.ethereum) {
                         connector.activate(injected, undefined, true)
-                    } else {
-                        if (isMobile && window.ethereum) {
-                            connector.activate(injected, undefined, true)
-                        }
                     }
-                })
-            }
+                }
+            })
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isActive, window?.ethereum])
 


### PR DESCRIPTION
closes #642 

## Description
- Fixes issue where wallet is not automatically re-connected on refresh

There was a line "if !(window.ethereum)" which was basically blocking the browser wallet from being able to reconnect automatically

- Fixes issue where a loading skeleton sometimes doesn't disappear in the onboarding section

I added a fallback that will load the image after 3 seconds if loading isn't set to true

- Partially fixed issue where wallet connect won't give up its connecton

By removing connector from the dependency array in WalletConnectV2Card we prevent an infinite loop from occurring that would prevent wallet connect from giving up its connection. Now we switch providers even if we're connected with wallet connect. The only issue remains that wallet connect doesn't realize when the websocket connection has been terminated and it'll still show that the user is connected.

- Fixed infinite re-rendering issue in onboarding section

In Vaults/index.tsx we had a setInterval that was fetching the user's vaults every 3000 ms. This was causing excessive re-renders and is totally unnecessary because we already have the useSafeData hook that's refetching that data anyway

## Screenshots

Autoconnect wallet on refresh

https://github.com/user-attachments/assets/68a6caf9-9f3a-4b0e-80e6-6f20d1eba929

Fallback if loading skeleton isn't disappearing

https://github.com/user-attachments/assets/a81fe3b3-fc0c-4f33-982f-f8655e98ab4b

User can switch from wallet connect to MetaMask

https://github.com/user-attachments/assets/a983c03b-1ef0-4cfa-a0a8-ae7de4235250





