### PR TITLE
Issue #663: Fix Gnosis Safe in app

### DIFF
--- a/src/components/ConnectedWalletInfo.tsx
+++ b/src/components/ConnectedWalletInfo.tsx
@@ -16,6 +16,7 @@ import { MetaMask } from '@web3-react/metamask'
 import { Info } from 'react-feather'
 import { Tooltip as ReactTooltip } from 'react-tooltip'
 import { useAddress } from '~/hooks/useAddress'
+import { GnosisSafe } from '@web3-react/gnosis-safe'
 
 const ConnectedWalletInfo = () => {
     const { t } = useTranslation()
@@ -80,8 +81,12 @@ const ConnectedWalletInfo = () => {
                     </LeftContainer>
 
                     <RightContainer>
-                        <Button text={'Change'} disabled={connector instanceof MetaMask} onClick={handleChange} />
-                        {connector instanceof MetaMask && (
+                        <Button
+                            text={'Change'}
+                            disabled={connector instanceof MetaMask || connector instanceof GnosisSafe}
+                            onClick={handleChange}
+                        />
+                        {(connector instanceof MetaMask || connector instanceof GnosisSafe) && (
                             <>
                                 <ReactTooltip id="browserWalletDisconnectTooltip" variant="light" data-effect="solid" />
                                 <Info

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,6 +25,7 @@ import walletIcon from '../assets/wallet-icon.svg'
 import DollarValueInner from './DollarValueInner'
 import { useAddress } from '~/hooks/useAddress'
 import Skeleton from 'react-loading-skeleton'
+import { GnosisSafe } from '@web3-react/gnosis-safe'
 
 const Navbar = () => {
     const { settingsModel: settingsState } = useStoreState((state) => state)
@@ -43,7 +44,7 @@ const Navbar = () => {
 
     const { popupsModel: popupsActions } = useStoreActions((state) => state)
     const { connectWalletModel } = useStoreState((state) => state)
-    const { isActive, account, provider, chainId } = useWeb3React()
+    const { isActive, account, provider, chainId, connector } = useWeb3React()
     const geb = useGeb()
     const odRef = useRef<HTMLDivElement | null>(null)
     const testTokenPopupRef = useRef<HTMLDivElement | null>(null)
@@ -125,9 +126,11 @@ const Navbar = () => {
 
     const handleWalletConnect = () => {
         if (isActive && account) {
-            return popupsActions.setIsConnectedWalletModalOpen(true)
+            popupsActions.setIsConnectedWalletModalOpen(true)
         }
-        return popupsActions.setIsConnectorsWalletOpen(true)
+        if (!(connector instanceof GnosisSafe)) {
+            return popupsActions.setIsConnectorsWalletOpen(true)
+        }
     }
 
     const handleLinkToDiscord = () => {

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -22,6 +22,7 @@ import DollarValueInner from './DollarValueInner'
 import parachuteIcon from '../assets/parachute-icon.svg'
 import { useAddress } from '~/hooks/useAddress'
 import Skeleton from 'react-loading-skeleton'
+import { GnosisSafe } from '@web3-react/gnosis-safe'
 
 const SideMenu = () => {
     const nodeRef = React.useRef(null)
@@ -34,7 +35,7 @@ const SideMenu = () => {
     })
     const popupRef = useRef<HTMLDivElement | null>(null)
     const priceRef = useRef<HTMLDivElement | null>(null)
-    const { isActive, account, chainId } = useWeb3React()
+    const { isActive, account, chainId, connector } = useWeb3React()
     const dollarRef = useRef<HTMLButtonElement | null>(null)
     const geb = useGeb()
     const odRef = useRef<HTMLButtonElement | null>(null)
@@ -50,7 +51,14 @@ const SideMenu = () => {
     const analyticsData = useAnalyticsData()
     let address = useAddress(account)
 
-    const handleWalletConnect = () => popupsActions.setIsConnectorsWalletOpen(true)
+    const handleWalletConnect = () => {
+        if (isActive && account) {
+            popupsActions.setIsConnectedWalletModalOpen(true)
+        }
+        if (!(connector instanceof GnosisSafe)) {
+            return popupsActions.setIsConnectorsWalletOpen(true)
+        }
+    }
 
     const handleDollarClick = () => {
         setPopupVisibility(!isPopupVisible)


### PR DESCRIPTION
closes #663 

## Description
I had to make various changes to ensure that Gnosis Safe is integrated properly in the app, such as preventing the MetaMask or NetworkConnector from hijacking the app before GnosisConnector gets a chance to connect

- Disabled "change" in the change wallet modal for Gnosis Safe (in addition to MM) to prevent mixing connectors while inside of the gnosis app context
- setIsConnectorsWalletOpen(true) in the handleWalletConnect() function in the nav and sidebar was throwing errors when using the GnosisConnector (and we shouldn't be able to switch wallets while in the gnosis app context anyway) so I exclude GnosisConnector from this
- I disabled the app from automatically connecting to the network RPC while in the safe context because we can connect to an RPC via the gnosis safe app and this code was hijacking the GnosisConnector. This also allows us to automatically reconnect to the GnosisConnector on refresh

## Screenshots

Note that my MetaMask wallet is connected to GnosisSafe but the Gnosis app context now correctly pulls my safe address (0x8F21) 
 
<img width="1314" alt="Screenshot 2024-07-25 at 8 43 11 PM" src="https://github.com/user-attachments/assets/6dc2d9dc-1408-443f-b3f6-f6cc33f89c2a">

There's a bug where the hero image sometimes doesn't resolve but I created another issue for this because it happens in other scenarios too

<img width="1303" alt="Screenshot 2024-07-25 at 8 37 56 PM" src="https://github.com/user-attachments/assets/e432fde7-62a5-4b71-8f94-535b059d0c3b">
