### PR TITLE
fix stability fee by removing multiplication

### DIFF
--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -11,7 +11,6 @@ import { AddressLink } from '~/components/AddressLink'
 import { contractsDescriptions } from '~/utils/contractsDescription'
 import {
     formatDataNumber,
-    multiplyRates,
     multiplyWad,
     transformToWadPercentage,
     transformToAnnualRate,

--- a/src/containers/Analytics/index.tsx
+++ b/src/containers/Analytics/index.tsx
@@ -299,13 +299,7 @@ const Analytics = () => {
                             <AddressLink address={value?.delayedOracle} chainId={chainId || 420} />,
                             formatDataNumber(value?.currentPrice?.toString() || '0', 18, 2, true),
                             formatDataNumber(value?.nextPrice?.toString() || '0', 18, 2, true),
-                            transformToAnnualRate(
-                                multiplyRates(
-                                    value?.stabilityFee?.toString(),
-                                    analyticsData.redemptionRate?.toString()
-                                ) || '0',
-                                27
-                            ),
+                            transformToAnnualRate(value?.stabilityFee?.toString(), 27),
                             formatDataNumber(value?.debtAmount?.toString() || '0', 18, 2, true, true),
                             transformToWadPercentage(value?.debtAmount?.toString(), value?.debtCeiling?.toString()),
                             formatDataNumber(value?.lockedAmount?.toString() || '0', 18, 2, false, true) + ' ' + key,


### PR DESCRIPTION
Stability fee was being multiplied by redemption rate. I removed this to show the correct fees

![image](https://github.com/user-attachments/assets/0fe96b1d-d694-474b-a5b9-230d58eaf466)
